### PR TITLE
Fix set syntax in gstreamer.py

### DIFF
--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -92,7 +92,7 @@ for encoder, name in encoders:
             ', disabling %s output.' % (encoder, name))
 
 if 'oggmux' not in available_elements:
-    del available_elements['vorbisenc']
+    available_elements.discard('vorbisenc')
 
 
 class Pipeline(BackgroundTask):
@@ -614,11 +614,11 @@ class Converter(Decoder):
             cmd += '%s=%s ' % (properties[self.mp3_mode][1], self.mp3_quality)
             #cmd += 'lowpass-freq=22000 '
 
-            if available_elements['xingmux'] and properties[self.mp3_mode][0]:
+            if 'xingmux' in available_elements and properties[self.mp3_mode][0]:
                 # add xing header when creating VBR mp3
                 cmd += '! xingmux '
 
-        if available_elements['id3v2mux']:
+        if 'id3v2mux' in available_elements:
             # add tags
             cmd += '! id3v2mux '
 


### PR DESCRIPTION
This caused a crash when starting to encode mp3s:

Traceback (most recent call last):
File "/usr/lib/soundconverter/python/soundconverter/ui.py", line 1309, in tags_read
self.converter.add(sound_file)
File "/usr/lib/soundconverter/python/soundconverter/gstreamer.py", line 762, in add
c.init()
File "/usr/lib/soundconverter/python/soundconverter/gstreamer.py", line 488, in init
encoder = self.encoders[self.output_type]()
File "/usr/lib/soundconverter/python/soundconverter/gstreamer.py", line 617, in add_mp3_encoder
if available_elements['xingmux'] and properties[self.mp3_mode][0]:
TypeError: 'set' object is not subscriptable

Original bug report is at https://bugs.archlinux.org/task/28150.

Signed-off-by: Jakob Gruber jakob.gruber@gmail.com
