### PR TITLE
set self.error in the on_error event handler

### DIFF
--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -596,7 +596,7 @@ class Converter(Decoder):
 
     def on_error(self, err):
         #pass
-
+        self.error = err
         show_error('<b>%s</b>' % _('GStreamer Error:'), '%s\n<i>(%s)</i>' % (err,
                     self.sound_file.filename_for_display))
 


### PR DESCRIPTION
I tried once to convert a file on a device having not enough place, with the "delete original files" option checked.
The converted file has not been created because of the missing place, but the original file has been deleted.

I set self.error in Converter.on_error, so the test "if self.delete_original and self.processing and not self.error:" properly fails in Converter.finished.

Please let me know if it is the good way to achieve this.
