### PR TITLE
CTRL+Q shortcut added to quit soundconverter

### DIFF
--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -2177,6 +2177,7 @@
                         <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
+                        <accelerator key="Q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_quit_activate" swapped="no"/>
                       </object>
                     </child>


### PR DESCRIPTION
No shortcut was defined to quit soundconverter. I added it in soundconverter.glade the same way it is done for the add and add_folder menu items.
