### PR TITLE
Fixed wrong filename bug with specialchars

### DIFF
--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -230,7 +230,7 @@ class FileList:
                 if len(uris) == 1:
                     # if only one folder is passed to the function,
                     # use its parent as base path.
-                    base = os.path.dirname(uri)
+                    base = str(gnomevfs.URI(os.path.dirname(uri)))
                 filelist = vfs_walk(gnomevfs.URI(uri))
                 accepted = []
                 if extensions:


### PR DESCRIPTION
When adding a folder that contains '&' (and probably other special chars):
os.path.dirname sticks to '&', but gnomevfs.URI converts this to "%26".

`filelist = vfs_walk(gnomevfs.URI(uri))` --> "%26"
`base = os.path.dirname(uri)` --> "&"

In `SoundFile.__init__()`, self.filename is created by cutting off the
length of the base. This leads to wrong filenames, so the output of
soundconverter was stored in wrong, newly created directories.

Maybe there are better ways to fix this issue -- I'm extremely unfamiliar with the codebase.

And as I'm already here:
soundconverter is an awesome project. Every time I use it I'm surprised by its simple user interface which still offers all of the functionality I need, although sound conversion itself isn't that easy. For me it's a showcase project for a clean UI that simplifies more complicated tasks for the enduser in a good way. Thanks a lot!
