### PR TITLE
fix: name 'vfs_exists' is not defined

### DIFF
--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -34,7 +34,7 @@ import gnomevfs
 from gconfstore import GConfStore
 from fileoperations import filename_to_uri, beautify_uri, vfs_writable, \
     vfs_exists
-from fileoperations import unquote_filename, vfs_walk
+from fileoperations import unquote_filename, vfs_walk, vfs_exists
 from fileoperations import use_gnomevfs
 from gstreamer import ConverterQueue
 from gstreamer import available_elements, TypeFinder


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib64/soundconverter/python/soundconverter/ui.py", line 1354, in on_convert_button_clicked
    self.do_convert()
  File "/usr/lib64/soundconverter/python/soundconverter/ui.py", line 1336, in do_convert
    self.converter.add(sound_file)
  File "/usr/lib64/soundconverter/python/soundconverter/gstreamer.py", line 663, in add
    output_filename = self.window.prefs.generate_temp_filename(sound_file) + '~SC~'
  File "/usr/lib64/soundconverter/python/soundconverter/ui.py", line 758, in generate_temp_filename
    if not vfs_exists(filename):
NameError: name 'vfs_exists' is not defined
