### PR TITLE
Add a missing Desktop sub-category

### DIFF
--- a/data/soundconverter.desktop.in.in
+++ b/data/soundconverter.desktop.in.in
@@ -9,5 +9,5 @@ Exec=soundconverter %U
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GNOME;GTK;AudioVideo;Audio;
+Categories=GNOME;GTK;AudioVideo;AudioVideoEditing;
 


### PR DESCRIPTION
@openSUSE is quite strict about this and enforces strict FreeDesktop compliance. I added a compatible one: https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#AudioVideo and removed the redundant second main category.