### PR TITLE
Put unknown length audio files last when sorting

### DIFF
--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -799,7 +799,8 @@ class ConverterQueue(TaskQueue):
         TaskQueue.abort(self)
         self.window.set_sensitive()
         self.reset_counters()
-    
+
     def start(self):
-        self.waiting_tasks.sort(key=Converter.get_duration,reverse=True)
+        key_lambda = lambda d: Converter.get_duration(d) if not Converter.get_duration(d) is None else 0
+        self.waiting_tasks.sort(key=key_lambda, reverse=True)
         TaskQueue.start(self)


### PR DESCRIPTION
Files without a length header/tag have a duration of `None`, which raise exceptions when sorting them before conversion :

`TypeError: unorderable types: NoneType() < NoneType()`

The behaviour is reproductible with these [audio files](http://www.thinkwithportals.com/music.php), which doesn't seem to have the duration header :

`% exiftool Portal2-01-Science_is_Fun.mp3
ExifTool Version Number         : 10.20
[...]
Duration                        : 0:02:33 (approx)`

`% mpv Portal2-01-Science_is_Fun.mp3
Playing: Portal2-01-Science_is_Fun.mp3
[ffmpeg/demuxer] mp3: Estimating duration from bitrate, this may be inaccurate`

Maybe there is a way to approximate length like with exiftool and mpv, but in the meantime this PR allow to convert such files.
