### PR TITLE
MP3 CBR 160kbps ("Moderate")

### DIFF
--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -1125,6 +1125,9 @@ Gautier Portet</property>
         <col id="0" translatable="yes">Normal</col>
       </row>
       <row>
+        <col id="0" translatable="yes">Moderate</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">High</col>
       </row>
       <row>

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -954,8 +954,8 @@ class PreferencesDialog(GladeWindow, GConfStore):
         quality = self.get_int(keys[mode])
 
         quality_to_preset = {
-            'cbr': {64: 0, 96: 1, 128: 2, 192: 3, 256: 4, 320: 5},
-            'abr': {64: 0, 96: 1, 128: 2, 192: 3, 256: 4, 320: 5},
+            'cbr': {64: 0, 96: 1, 128: 2, 160: 3, 192: 4, 256: 5, 320: 6},
+            'abr': {64: 0, 96: 1, 128: 2, 160: 3, 192: 4, 256: 5, 320: 6},
             'vbr': {9: 0, 7: 1, 5: 2, 3: 3, 1: 4, 0: 5}, # inverted !
         }
 
@@ -982,8 +982,8 @@ class PreferencesDialog(GladeWindow, GConfStore):
             'vbr': 'mp3-vbr-quality'
         }
         quality = {
-            'cbr': (64, 96, 128, 192, 256, 320),
-            'abr': (64, 96, 128, 192, 256, 320),
+            'cbr': (64, 96, 128, 160, 192, 256, 320),
+            'abr': (64, 96, 128, 160, 192, 256, 320),
             'vbr': (9, 7, 5, 3, 1, 0),
         }
         mode = self.get_string('mp3-mode')


### PR DESCRIPTION
This changes add "Moderate" `160 kbps` to the selectable MP3 CBR qualities.

<img width="475" alt="screen shot 2018-02-06 at 13 58 16" src="https://user-images.githubusercontent.com/473924/35860838-d3943a46-0b45-11e8-9557-af80b8178b37.png">
