### PR TITLE
Use artist when creating subfolders and album-artist not set

### DIFF
--- a/soundconverter/namegenerator.py
+++ b/soundconverter/namegenerator.py
@@ -87,6 +87,9 @@ class TargetNameGenerator:
                 d[key] = d[key].replace('/', '-')
                 if key.endswith('-number'):
                     d[key] = int(d[key])
+        # when artist set & album-artist not, use artist for album-artist
+        if 'artist' in sound_file.tags and 'album-artist' not in sound_file.tags:
+            d['album-artist'] = sound_file.tags['artist']
 
         # add timestamp to substitution dict -- this could be split into more
         # entries for more fine-grained control over the string by the user...


### PR DESCRIPTION
When using “_Create subfolders_”, soundconverter only looks at a sound file’s ‘album-artist’ tag to create the destination path. Music files often have ‘artist’ set and ‘album-artist’ left blank (eg. for single-artist albums). In such cases soundconverter saves everything to a single “Unknown Artist” folder: ‘Unknown Artist/Symphony № 6, Pastoral’; ‘‘Unknown Artist/Scary Monsters'; ‘Unknown Artist/Your Queen is a Reptile’; etc. Later one can manually create ‘Ludwig van Beethoven’/‘David Bowie’/‘Sons of Kemet’ folders, move each album there, and delete the ‘Unknown Artist’ folder, but this isn’t an ideal user experience.

This patch uses a sound file’s ‘artist’ tag when ‘album-artist’ is unset, which prevents the above busywork and shouldn’t affect the album-artist-is-available use case.