### PR TITLE
Better CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ po/stamp-it
 po/.intltool-merge-cache
 data/soundconverter.desktop
 data/soundconverter.desktop.in
+INSTALL
+bin/soundconverter
+compile
+data/org.soundconverter.gschema.valid
+m4/
+py-compile
+
+# paths that don't exist (remove from .gitignore, what is this?)
 src/soundconverter
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ py-compile
 
 # paths that don't exist (remove from .gitignore, what is this?)
 src/soundconverter
+
+# python
+__pycache__

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -157,6 +157,9 @@ def parse_command_line():
     parser.add_option('-o', '--output', action="store", dest="output-path",
         help=_('Put converted files into a different directory while maintaining '
             'the original directory structure'))
+    parser.add_option('-Q', '--quality', action="store", type='int', dest="quality",
+        metavar='NUM', help=_('Quality of the converted output file. Between 0 '
+            '(lowest) and 5 (highest)'))
 
     # not implemented yet
     # parser.add_option('--help-gst', action="store_true", dest="_unused",

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -118,7 +118,10 @@ class ModifiedOptionParser(OptionParser):
 def parse_command_line():
     parser = ModifiedOptionParser(epilog='\nExamples:\n'
         '  soundconverter -b [original file 1] [original file 2] -m mp3 -s .mp3\n'
-        '  soundconverter -b [original directory] -r -m audio/x-vorbis -s .opus\n')
+        '    Creates files with an .mp3 suffix in the same dirs as the input files.\n'
+        '  soundconverter -b [original dir] -r -m audio/x-vorbis -s .opus -o [output dir]\n'
+        '    Creates the original subdirectory structure in the output directory and\n'
+        '    stores the converted files in it.\n')
 
     parser.add_option('-b', '--batch', dest='mode', action='callback',
         callback=mode_callback, callback_kwargs={'mode':'batch'},
@@ -133,7 +136,9 @@ def parse_command_line():
     parser.add_option('-m', '--mime-type', dest="cli-output-type",
         help=_('Set the output MIME type for batch mode. The default '
             'is %s. Note that you probably want to set the output '
-            'suffix as well.') % settings['cli-output-type'])
+            'suffix as well. Supported shortcuts and mime types: aac '
+            'audio/x-m4a flac audio/x-flac mp3 audio/mpeg vorbis audio/x-vorbis '
+            'wav audio/x-wav') % settings['cli-output-type'])
     parser.add_option('-q', '--quiet', action="store_true", dest="quiet",
         help=_("Be quiet. Don't write normal output, only errors."))
     parser.add_option('-d', '--debug', action="store_true", dest="debug",

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -41,17 +41,17 @@ GLADEFILE = '@datadir@/soundconverter/soundconverter.glade'
 
 PACKAGE = NAME.lower()
 try: 
-    locale.setlocale(locale.LC_ALL,'')
-    locale.bindtextdomain(PACKAGE,'@datadir@/locale')
-    gettext.bindtextdomain(PACKAGE,'@datadir@/locale')
+    locale.setlocale(locale.LC_ALL, '')
+    locale.bindtextdomain(PACKAGE, '@datadir@/locale')
+    gettext.bindtextdomain(PACKAGE, '@datadir@/locale')
     gettext.textdomain(PACKAGE)
-    gettext.install(PACKAGE,localedir='@datadir@/locale')
+    gettext.install(PACKAGE, localedir='@datadir@/locale')
     #from gettext import gettext as _
 except locale.Error:
     print('  cannot use system locale.')
-    locale.setlocale(locale.LC_ALL,'C')
+    locale.setlocale(locale.LC_ALL, 'C')
     gettext.textdomain(PACKAGE)
-    gettext.install(PACKAGE,localedir='@datadir@/locale')
+    gettext.install(PACKAGE, localedir='@datadir@/locale')
 
 def _add_soundconverter_path():
     global localedir
@@ -91,8 +91,8 @@ def check_mime_type(mime):
     if mime not in list(types.values()):
         print(('Cannot use "%s" mime type.' % mime))
         msg = 'Supported shortcuts and mime types:'
-        for k,v in sorted(types.items()):
-            msg += ' %s %s' % (k,v)
+        for k, v in sorted(types.items()):
+            msg += ' %s %s' % (k, v)
         print(msg)
         raise SystemExit
     return mime
@@ -196,7 +196,6 @@ except:
         settings['mode'] = 'batch'
 
 if settings['mode'] == 'gui':
-    files = list(map(filename_to_uri, files))
     gui_main(NAME, VERSION, GLADEFILE, files)
 else:
     if not files:

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -147,7 +147,11 @@ def parse_command_line():
     parser.add_option('-r', '--recursive', action="store_true", dest="recursive",
         help=_('Go recursively into subdirectories'))
     parser.add_option('-i', '--ignore', action="store_true", dest="ignore-existing",
-        help=_('Ignore files for which the target already exists instead of converting them again'))
+        help=_('Ignore files for which the target already exists instead '
+            'of converting them again'))
+    parser.add_option('-o', '--output', action="store", dest="output-path",
+        help=_('Put converted files into a different directory while maintaining '
+            'the original directory structure'))
 
     # not implemented yet
     # parser.add_option('--help-gst', action="store_true", dest="_unused",

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -159,7 +159,7 @@ def parse_command_line():
             'the original directory structure'))
     parser.add_option('-Q', '--quality', action="store", type='int', dest="quality",
         metavar='NUM', help=_('Quality of the converted output file. Between 0 '
-            '(lowest) and 5 (highest)'))
+            '(lowest) and 5 (highest). Default is 3.'), default=3)
 
     # not implemented yet
     # parser.add_option('--help-gst', action="store_true", dest="_unused",

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -71,6 +71,8 @@ class CliProgress:
 
 
 def cli_convert_main(input_files):
+    """input_files is an array of strings"""
+
     loop = GLib.MainLoop()
     context = loop.get_context()
     error.set_error_handler(error.ErrorPrinter())

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -157,7 +157,11 @@ def cli_convert_main(input_files):
         
         # skip existing output files if desired (-i cli argument)
         if 'ignore-existing' in settings and settings['ignore-existing'] and vfs_exists(output_name):
-            print('{}: already exists, skipping'.format(unquote_filename(output_name.split(os.sep)[-1][-65:])))
+            print('skipping \'{}\': already exists'.format(unquote_filename(output_name.split(os.sep)[-1][-65:])))
+            continue
+
+        if input_file.uri == output_name:
+            print('skipping \'{}\': output path is the same as the input path'.format(unquote_filename(output_name.split(os.sep)[-1][-65:])))
             continue
 
         c = Converter(input_file, output_name, output_type)

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -160,6 +160,14 @@ def cli_convert_main(input_files):
             continue
 
         c = Converter(input_file, output_name, output_type)
+
+        if 'quality' in settings:
+            quality_setting = settings.get('quality')
+            c.set_vorbis_quality(get_quality('vorbis', quality_setting))
+            c.set_aac_quality(get_quality('aac', quality_setting))
+            c.set_opus_quality(get_quality('opus', quality_setting))
+            c.set_mp3_quality(get_quality('mp3', quality_setting))
+
         c.overwrite = True
         c.init()
         c.start()

--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -502,7 +502,7 @@ class Converter(Decoder):
 
     def __init__(self, sound_file, output_filename, output_type,
                  delete_original=False, output_resample=False,
-                 resample_rate=48000, force_mono=False):
+                 resample_rate=48000, force_mono=False, ignore_errors=False):
         Decoder.__init__(self, sound_file)
 
         self.output_filename = output_filename
@@ -521,6 +521,8 @@ class Converter(Decoder):
 
         self.overwrite = False
         self.delete_original = delete_original
+
+        self.ignore_errors = ignore_errors
 
         self.got_duration = False
 
@@ -587,9 +589,13 @@ class Converter(Decoder):
                 log('Cannot remove \'%s\'' % beautify_uri(self.output_filename))
 
     def on_error(self, error):
-        Pipeline.on_error(self, error)
-        show_error('<b>%s</b>' % _('GStreamer Error:'),
-                   '%s\n<i>(%s)</i>' % (error, self.sound_file.filename_for_display))
+        if self.ignore_errors:
+            self.error = error
+            log('ignored-error: %s (%s)' % (error, ' ! '.join(self.command)))
+        else:
+            Pipeline.on_error(self, error)
+            show_error('<b>%s</b>' % _('GStreamer Error:'),
+                    '%s\n<i>(%s)</i>' % (error, self.sound_file.filename_for_display))
 
     def set_vorbis_quality(self, quality):
         self.vorbis_quality = quality

--- a/soundconverter/settings.py
+++ b/soundconverter/settings.py
@@ -143,7 +143,7 @@ def get_quality(ftype, value, mode='vbr', reverse=False):
     # return depending on function parameters
     if reverse:
         if type(value) == float:
-            # floats are inaccurate, search for closest value
+            # floats are inaccurate, search for close value
             for i, q in enumerate(qualities):
                 if abs(value - q) < 0.01:
                     return i

--- a/soundconverter/settings.py
+++ b/soundconverter/settings.py
@@ -103,3 +103,50 @@ settings = {
     'cpu-count': cpu_count(),
     'forced-jobs': None,
 }
+
+
+# I moved this here so that both batch and ui have
+# access to the numbers of the quality settings.
+# Also to reduce redundancy of the hard-coded
+# quality tuples.
+def get_quality(ftype, value, mode='vbr', reverse=False):
+    """get quality from integers between 0 and 6
+    depending on target file type
+    
+    ftype of 'vorbis', 'aac', 'opus' or 'mp3',
+    value between 0 and 5,
+    mode one of 'cbr', 'abr' and 'vbr' for mp3
+
+    reverse is by default False. If True, this
+    function returns the original value-parameter
+    given a quality setting.
+    """
+
+    quality = {
+        'vorbis': (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),
+        'aac': (64, 96, 128, 192, 256, 320),
+        'opus': (48, 64, 96, 128, 160, 192),
+        'mp3': {
+            'cbr': (64, 96, 128, 192, 256, 320),
+            'abr': (64, 96, 128, 192, 256, 320),
+            'vbr': (9, 7, 5, 3, 1, 0), # inverted !
+        }
+    }
+
+    # get 6-tuple of qualities
+    qualities = None
+    if ftype == 'mp3':
+        qualities = quality[ftype][mode]
+    else:
+        qualities = quality[ftype]
+
+    # return depending on function parameters
+    if reverse:
+        if type(value) == float:
+            # floats are inaccurate, search for closest value
+            for i, q in enumerate(qualities):
+                if abs(value - q) < 0.01:
+                    return i
+        return qualities.index(value)
+    else:
+        return qualities[value]

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -1413,10 +1413,14 @@ NAME = VERSION = None
 win = None
 
 def gui_main(name, version, gladefile, input_files):
+    """input_files is an array of paths"""
+
     global NAME, VERSION
     NAME, VERSION = name, version
     GLib.set_application_name(name)
     GLib.set_prgname(name)
+
+    input_files = list(map(filename_to_uri, input_files))
 
     builder = Gtk.Builder()
     builder.set_translation_domain(name.lower())

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -1396,7 +1396,7 @@ NAME = VERSION = None
 win = None
 
 def gui_main(name, version, gladefile, input_files):
-    """input_files is an array of paths"""
+    """input_files is an array of string paths"""
 
     global NAME, VERSION
     NAME, VERSION = name, version


### PR DESCRIPTION
I was having trouble with the command line interface, mostly due to missing features.

So I set up some directories containing files that should be converted with a subdirectory structure and worked on the soundconverter cli until I was able to convert them into a target directory.

added -i, -r, -Q and -o options:
- -r goes into subdirectories
- -i ignores files that have already been converted
- -o specifies an output directory in which the original file structure is restored
- -Q takes values between 0 and 5 and indicates the quality of the conversion

furthermore:
- removed --help-gst from help since it is not used
- added example usage to --help
- reduced redundancy of quality numbers in ui.py with get_quality in settings.py

in .gitignore was a path "src/soundconverter". This is something old and can be removed, right?