### PR TITLE
Threaded batch mode

### DIFF
--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -313,7 +313,7 @@ class CLI_Check():
         context.iteration(True)
 
         if not silent:
-            log('\nBroken Files:')
+            log('\nNon-Audio Files:')
 
             for input_file in input_files:
                 if not input_file in self.good_files:

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -285,6 +285,7 @@ class FileList:
         self.typefinders.start()
 
         self.window.set_status('{}'.format(_('Adding Files...')))
+        log('adding: %d files' % len(files))
 
         # show progress and enable gtk main loop iterations
         # so that the ui stays responsive
@@ -296,10 +297,9 @@ class FileList:
                 self.window.progressbarstatus.set_fraction(self.typefinders.progress)
                 self.window.progressbarstatus.set_text('{}/{}'.format(completed, len(files)))
             gtk_iteration()
-            time.sleep(0.1)
+            # time.sleep(0.1) # slows everything down. why does the taskqueue depend
+            # on gtk_iteration being called like a maniac?
         self.window.progressbarstatus.set_show_text(False)
-
-        log('adding: %d files' % len(files))
 
         # see if one of the files with an audio extension
         # was not readable.

--- a/soundconverter/utils.py
+++ b/soundconverter/utils.py
@@ -25,8 +25,8 @@ from .settings import settings
 from gi.repository import GLib
 
 def log(*args):
-    """ Display a message.
-    Can be disabled with 'quiet' option """
+    """ Display a message. Can be disabled
+    with the 'quiet' option (-q) """
     if not settings['quiet']:
         print(( ' '.join([str(msg) for msg in args]) ))
 


### PR DESCRIPTION
- **threaded conversion in batch mode**
- reduced number of prints with -q
- -t option: when -q is provided don't print nothing at all, rather just hide errors and files without tags
    because otherwise the combination of -t and -q makes no sense at all
- removed info about which gtk version is used and such. Not relevant to the user
- fixed an error from one of my recent commits
- added -c mode, doing what the gtk interface does when loading files. showing which ones cannot
be converted.
- the CliProgress class accepts multiple arguments like print to create messages now:
show("a", "b")
- nicer console output

example output of -b (-q disables all output):
```
SoundConverter 3.0.1

checking files and walking dirs in the specified paths...
Queue start: 36 tasks, 4 thread(s).
Queue done in 0.052s (36 tasks)

preparing converters...
overwriting '/funky_files/converted/original/audio 2.ogg'
skipping 'not_music.ogg': invalid soundfile
skipping 'not_music.flac': invalid soundfile
(...)
overwriting '/funky_files/converted/original/foo/audio 4.ogg'
overwriting '/funky_files/converted/original/foo/bar/audio 5.ogg'
overwriting '/funky_files/converted/original/foo/bar/audio 6.ogg'

starting conversion...
Queue start: 6 tasks, 4 thread(s).
1/6: '/funky_files/original/audio 2.flac'
2/6: '/funky_files/original/audio 1.flac'
3/6: '/funky_files/original/foo/audio 3.flac'
4/6: '/funky_files/original/foo/audio 4.flac'
5/6: '/funky_files/original/foo/bar/audio 5.flac'
6/6: '/funky_files/original/foo/bar/audio 6.opus'
Queue done in 12.346s (6 tasks)
```

example output of -c (-q just prints a naked list of file paths):
```
SoundConverter 3.0.1
Queue start: 36 tasks, 4 thread(s).
Queue done in 0.052s (36 tasks)

Non-Audio Files:
/funky_files/original/not_music.ogg
/funky_files/original/not_music.flac
(...)
/funky_files/original/pictures/pic (another copy).jpg
```