### PR TITLE
Quote base folder when building target paths.

### DIFF
--- a/soundconverter/namegenerator.py
+++ b/soundconverter/namegenerator.py
@@ -118,6 +118,6 @@ class TargetNameGenerator:
             # we are creating folders using tags, disable basefolder handling
             basefolder = ''
 
-        result = os.path.join(folder, basefolder, urllib.parse.quote(result))
+        result = os.path.join(folder, urllib.parse.quote(basefolder), urllib.parse.quote(result))
 
         return result


### PR DESCRIPTION
The basefolder is not quoted as it should be.
If the converted file is within a subdirectory containing for example a # sign,
soundconverter would hang.