### PR TITLE
logging, format strings, tests don't change settings, split tests, --gst- arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ __pycache__
 
 # IDEs
 .vscode
+
+tests/tmp

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,4 +22,4 @@ changelog:
 	cat ChangeLog.old >> ChangeLog
 
 test:
-	PYTHONPATH=. python3 tests/unittests.py 
+	PYTHONPATH=. python3 tests/test.py

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,44 @@ Wave        yes
 MP3         yes
 ==========  ==========
 
+Building and installation
+-------------------------
+
+To build and run from the latest source, use::
+
+    git clone https://github.com/kassoulet/soundconverter.git
+    cd soundconverter
+    git checkout py3k
+    ./autogen.sh
+    make
+    sudo make install
+    soundconverter
+
+It is also available in the arch repositories::
+
+    sudo pacman -S soundconverter
+
+As well as the debian repositories::
+
+    sudo apt install soundconverter
+
+Help
+----
+
+For command line args, see
+
+    sounconverter --help
+    gst-launch-1.0 --help-gst
+
+and https://gstreamer.freedesktop.org/documentation/application-development/appendix/checklist-element.html
+
+Testing
+-------
+
+To start unittests, use::
+
+    make test
+
 Copyright and acknowledgements
 ------------------------------
 
@@ -82,31 +120,4 @@ Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-
-Building and installation
--------------------------
-
-To build from the latest source, use::
-
-    git clone https://github.com/kassoulet/soundconverter.git
-    cd soundconverter
-    git checkout py3k
-    ./autogen.sh
-    make
-    sudo make install
-
-It is also available in the arch repositories::
-
-    sudo pacman -S soundconverter
-
-As well as the debian repositories::
-
-    sudo apt install soundconverter
-
-Testing
--------
-
-To start unittests, use::
-
-    make test
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Testing
 
 To start unittests, use::
 
-    make test
+    make && make test
 
 Copyright and acknowledgements
 ------------------------------

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -82,7 +82,7 @@ from soundconverter.fileoperations import vfs_encode_filename
 from soundconverter.batch import CLI_Convert, cli_tags_main, CLI_Check
 from soundconverter.fileoperations import filename_to_uri
 from soundconverter.ui import gui_main
-from soundconverter.utils import log, update_verbosity
+from soundconverter.utils import logger, update_verbosity
 
 # command line argument parsing, launch-mode
 
@@ -94,11 +94,11 @@ def check_mime_type(mime):
     }
     mime = types.get(mime, mime)
     if mime not in list(types.values()):
-        log(('Cannot use "%s" mime type.' % mime))
+        logger.info(('Cannot use "%s" mime type.' % mime))
         msg = 'Supported shortcuts and mime types:'
         for k, v in sorted(types.items()):
             msg += ' %s %s' % (k, v)
-        log(msg)
+        logger.info(msg)
         raise SystemExit
     return mime
 
@@ -247,15 +247,15 @@ settings['cli-output-type'] = check_mime_type(settings['cli-output-type'])
 update_verbosity()
 
 if not settings.get('quiet'):
-    log(('%s %s' % (NAME, VERSION)))
+    logger.info(('%s %s' % (NAME, VERSION)))
     if settings['forced-jobs']:
-        log(('Using %d thread(s)' % settings['forced-jobs']))
+        logger.info(('Using %d thread(s)' % settings['forced-jobs']))
 
 if settings['mode'] == 'gui':
     gui_main(NAME, VERSION, GLADEFILE, files)
 else:
     if not files:
-        log('nothing to do…')
+        logger.info('nothing to do…')
     if settings['mode'] == 'tags':
         cli_tags_main(files)
     elif settings['mode'] == 'batch':

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -132,7 +132,7 @@ def parse_command_line():
         '-c', '--check', dest='mode', action='callback',
         callback=mode_callback, callback_kwargs={'mode': 'check'},
         help=_(
-            'log which files cannot be read by gstreamer. '
+            'Log which files cannot be read by gstreamer. '
             'Useful before converting. This will disable the GUI and '
             'run in batch mode, from the command line.'
         )

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -29,7 +29,7 @@ import locale
 import gettext
 from optparse import OptionParser, OptionGroup
 
-# variables
+# variables, populated by make when installed to /usr/local/bin/soundconverter
 LIBDIR = '@libdir@'
 DATADIR = '@datadir@'
 NAME = 'SoundConverter'
@@ -78,25 +78,22 @@ soundconverter.NAME = NAME
 soundconverter.VERSION = VERSION
 soundconverter.GLADEFILE = GLADEFILE
 from soundconverter.settings import settings
-from soundconverter.fileoperations import vfs_encode_filename
+from soundconverter.formats import get_mime_type, mime_types
+from soundconverter.fileoperations import vfs_encode_filename, filename_to_uri
 from soundconverter.batch import CLI_Convert, cli_tags_main, CLI_Check
-from soundconverter.fileoperations import filename_to_uri
 from soundconverter.ui import gui_main
 from soundconverter.utils import logger, update_verbosity
 
 # command line argument parsing, launch-mode
 
 
-def check_mime_type(mime):
-    types = {
-        'vorbis': 'audio/x-vorbis', 'flac': 'audio/x-flac', 'wav': 'audio/x-wav',
-        'mp3': 'audio/mpeg', 'aac': 'audio/x-m4a'
-    }
-    mime = types.get(mime, mime)
-    if mime not in list(types.values()):
+def check_mime_type(t):
+    """Exit soundconverter if the type is not supported"""
+    mime = get_mime_type(t)
+    if mime is None:
         logger.info('Cannot use "{}" mime type.'.format(mime))
         msg = 'Supported shortcuts and mime types:'
-        for k, v in sorted(types.items()):
+        for k, v in sorted(mime_types.items()):
             msg += ' {} {}'.format(k, v)
         logger.info(msg)
         raise SystemExit
@@ -223,10 +220,6 @@ def parse_command_line():
     )
 
     parser.add_option_group(batch_option_group)
-
-    # not implemented yet
-    # parser.add_option('--help-gst', action="store_true", dest="_unused",
-    #     help=_('Shows GStreamer Options'))
 
     return parser
 

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -43,7 +43,7 @@ try:
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gst, Gtk, GLib, Gdk
 except (ImportError, ValueError) as error:
-    print(('%s needs GTK >= 3.0 (Error: "%s")' % (NAME, error)))
+    print(('{} needs GTK >= 3.0 (Error: "{}")'.format(NAME, error)))
     sys.exit(1)
 
 # remove gstreamer arguments so only gstreamer sees them. See `gst-launch-1.0 --help-gst`
@@ -94,10 +94,10 @@ def check_mime_type(mime):
     }
     mime = types.get(mime, mime)
     if mime not in list(types.values()):
-        logger.info(('Cannot use "%s" mime type.' % mime))
+        logger.info('Cannot use "{}" mime type.'.format(mime))
         msg = 'Supported shortcuts and mime types:'
         for k, v in sorted(types.items()):
-            msg += ' %s %s' % (k, v)
+            msg += ' {} {}'.format(k, v)
         logger.info(msg)
         raise SystemExit
     return mime
@@ -180,7 +180,7 @@ def parse_command_line():
             'Set the output MIME type. The default '
             'is %s. Note that you will probably want to set the output '
             'suffix as well. Supported MIME types: %s'
-        ) % (
+        ).format(
             settings['cli-output-type'],
             'audio/x-m4a (AAC) audio/x-flac (FLAC) audio/mpeg (MP3) audio/x-vorbis (Vorbis)'
             'audio/x-wav (WAV)'
@@ -192,7 +192,7 @@ def parse_command_line():
             'Set the output filename suffix. '
             'The default is %s. Note that the suffix does not '
             'affect\n the output MIME type.'
-        ) % settings['cli-output-suffix']
+        ).format(settings['cli-output-suffix'])
     )
     batch_option_group.add_option(
         '-r', '--recursive', action="store_true", dest="recursive",
@@ -247,9 +247,9 @@ settings['cli-output-type'] = check_mime_type(settings['cli-output-type'])
 update_verbosity()
 
 if not settings.get('quiet'):
-    logger.info(('%s %s' % (NAME, VERSION)))
+    logger.info(('{} {}'.format(NAME, VERSION)))
     if settings['forced-jobs']:
-        logger.info(('Using %d thread(s)' % settings['forced-jobs']))
+        logger.info(('Using {} thread(s)'.format(settings['forced-jobs'])))
 
 if settings['mode'] == 'gui':
     gui_main(NAME, VERSION, GLADEFILE, files)

--- a/bin/soundconverter.py
+++ b/bin/soundconverter.py
@@ -244,6 +244,7 @@ for k in dir(options):
 
 settings['cli-output-type'] = check_mime_type(settings['cli-output-type'])
 
+# now that the settings are populated, the verbosity can be determined:
 update_verbosity()
 
 if not settings.get('quiet'):

--- a/data/org.soundconverter.gschema.xml
+++ b/data/org.soundconverter.gschema.xml
@@ -126,8 +126,8 @@
       <summary></summary>
       <description></description>
     </key>
-    <key name="limit-jobs" type="i">
-      <default>0</default>
+    <key name="limit-jobs" type="b">
+      <default>false</default>
       <summary>Limit jobs</summary>
       <description></description>
     </key>    

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -10,6 +10,7 @@ soundconverter/namegenerator.py
 soundconverter/notify.py
 soundconverter/queue.py
 soundconverter/settings.py
+soundconverter/formats.py
 soundconverter/soundfile.py
 soundconverter/task.py
 soundconverter/ui.py

--- a/soundconverter/Makefile.am
+++ b/soundconverter/Makefile.am
@@ -11,6 +11,7 @@ soundconverter_PYTHON = \
 	notify.py	\
 	queue.py	\
 	settings.py	\
+	formats.py	\
 	soundfile.py	\
 	task.py	\
 	ui.py	\

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -87,7 +87,7 @@ def prepare_files_list(input_files):
                         subdirectories.append(subdir)
             else:
                 # else it didn't go into any directory. provide some information about how to
-                logger.info('%s is a directory. Use -r to go into all subdirectories.' % input_path)
+                logger.info('{} is a directory. Use -r to go into all subdirectories.'.format(input_path))
         # if not a file and not a dir it doesn't exist. skip
     parsed_files = list(map(filename_to_uri, parsed_files))
 
@@ -116,7 +116,7 @@ def cli_tags_main(input_files):
         if len(input_file.tags) > 0:
             logger.info(unquote_filename(input_file.filename))
             for key in sorted(input_file.tags):
-                logger.info(('     %s: %s' % (key, input_file.tags[key])))
+                logger.info(('     {}: {}'.format(key, input_file.tags[key])))
         else:
             logger.info(unquote_filename(input_file.filename))
             logger.info(('     no tags found'))

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -115,9 +115,9 @@ def cli_tags_main(input_files):
             context.iteration(True)
 
         if len(input_file.tags) > 0:
-            print(unquote_filename(input_file.filename))
+            log(unquote_filename(input_file.filename))
             for key in sorted(input_file.tags):
-                print(('     %s: %s' % (key, input_file.tags[key])))
+                log(('     %s: %s' % (key, input_file.tags[key])))
         else:
             log(unquote_filename(input_file.filename))
             log(('     no tags found'))
@@ -314,7 +314,7 @@ class CLI_Check():
 
             for input_file in input_files:
                 if input_file not in self.good_files:
-                    print(unquote_filename(beautify_uri(input_file)))
+                    log(unquote_filename(beautify_uri(input_file)))
 
     def found_type(self, sound_file, mime):
         self.good_files.append(sound_file.uri)

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -116,10 +116,10 @@ def cli_tags_main(input_files):
         if len(input_file.tags) > 0:
             logger.info(unquote_filename(input_file.filename))
             for key in sorted(input_file.tags):
-                logger.info(('     {}: {}'.format(key, input_file.tags[key])))
+                logger.info(('    {}: {}'.format(key, input_file.tags[key])))
         else:
             logger.info(unquote_filename(input_file.filename))
-            logger.info(('     no tags found'))
+            logger.info(('    no tags found'))
 
 
 class CliProgress:

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -28,7 +28,8 @@ import time
 from gi.repository import Gtk, GLib
 from soundconverter.soundfile import SoundFile
 from soundconverter import error
-from soundconverter.settings import settings, get_quality
+from soundconverter.settings import settings
+from soundconverter.formats import get_quality
 from soundconverter.gstreamer import TagReader, TypeFinder
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.queue import TaskQueue

--- a/soundconverter/batch.py
+++ b/soundconverter/batch.py
@@ -34,7 +34,7 @@ from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.queue import TaskQueue
 from soundconverter.gstreamer import Converter
 from soundconverter.fileoperations import unquote_filename, filename_to_uri, vfs_exists, beautify_uri
-from soundconverter.utils import log
+from soundconverter.utils import logger
 
 
 def prepare_files_list(input_files):
@@ -87,7 +87,7 @@ def prepare_files_list(input_files):
                         subdirectories.append(subdir)
             else:
                 # else it didn't go into any directory. provide some information about how to
-                log(input_path, 'is a directory. Use -r to go into all subdirectories.')
+                logger.info('%s is a directory. Use -r to go into all subdirectories.' % input_path)
         # if not a file and not a dir it doesn't exist. skip
     parsed_files = list(map(filename_to_uri, parsed_files))
 
@@ -103,7 +103,6 @@ def cli_tags_main(input_files):
     input_files is an array of string paths.
     """
     input_files, _ = prepare_files_list(input_files)
-    error.set_error_handler(error.ErrorPrinter())
     loop = GLib.MainLoop()
     context = loop.get_context()
     for input_file in input_files:
@@ -115,12 +114,12 @@ def cli_tags_main(input_files):
             context.iteration(True)
 
         if len(input_file.tags) > 0:
-            log(unquote_filename(input_file.filename))
+            logger.info(unquote_filename(input_file.filename))
             for key in sorted(input_file.tags):
-                log(('     %s: %s' % (key, input_file.tags[key])))
+                logger.info(('     %s: %s' % (key, input_file.tags[key])))
         else:
-            log(unquote_filename(input_file.filename))
-            log(('     no tags found'))
+            logger.info(unquote_filename(input_file.filename))
+            logger.info(('     no tags found'))
 
 
 class CliProgress:
@@ -161,7 +160,7 @@ class CLI_Convert():
         """
         # check which files should be converted. The result is
         # stored in file_checker.good_files
-        log('\nchecking files and walking dirs in the specified paths…')
+        logger.info('\nchecking files and walking dirs in the specified paths…')
 
         file_checker = CLI_Check(input_files, silent=True)
 
@@ -174,7 +173,6 @@ class CLI_Convert():
 
         loop = GLib.MainLoop()
         context = loop.get_context()
-        error.set_error_handler(error.ErrorPrinter())
 
         output_type = settings['cli-output-type']
         output_suffix = settings['cli-output-suffix']
@@ -187,11 +185,11 @@ class CLI_Convert():
         self.started_tasks = 0
         self.num_conversions = 0
 
-        log('\npreparing converters…')
+        logger.info('\npreparing converters…')
         for i, input_file in enumerate(input_files):
 
             if input_file not in file_checker.good_files:
-                log('skipping \'{}\': invalid soundfile'.format(unquote_filename(input_file.split(os.sep)[-1][-65:])))
+                logger.info('skipping \'{}\': invalid soundfile'.format(unquote_filename(input_file.split(os.sep)[-1][-65:])))
                 continue
 
             input_file = SoundFile(input_file)
@@ -209,7 +207,7 @@ class CLI_Convert():
 
             # skip existing output files if desired (-i cli argument)
             if settings.get('ignore-existing') and vfs_exists(output_name):
-                log('skipping \'{}\': already exists'.format(unquote_filename(output_name.split(os.sep)[-1][-65:])))
+                logger.info('skipping \'{}\': already exists'.format(unquote_filename(output_name.split(os.sep)[-1][-65:])))
                 continue
 
             c = Converter(input_file, output_name, output_type)
@@ -231,10 +229,10 @@ class CLI_Convert():
             self.num_conversions += 1
 
         if self.num_conversions == 0:
-            log('\nnothing to do…')
+            logger.info('\nnothing to do…')
             exit(2)
 
-        log('\nstarting conversion…')
+        logger.info('\nstarting conversion…')
         conversions.start()
         while conversions.running:
             # calling this like crazy is the fastest way
@@ -247,7 +245,7 @@ class CLI_Convert():
         """Print the filename that is currently being converted and how many files are left."""
         self.started_tasks += 1
         path = unquote_filename(beautify_uri(c.sound_file.uri))
-        log('{}/{}: \'{}\''.format(self.started_tasks, self.num_conversions, path))
+        logger.info('{}/{}: \'{}\''.format(self.started_tasks, self.num_conversions, path))
 
 
 class CLI_Check():
@@ -275,8 +273,6 @@ class CLI_Check():
         # provide this to other code that uses CLI_Check
         self.input_files = input_files
         self.subdirectories = subdirectories
-
-        error.set_error_handler(error.ErrorPrinter())
 
         typefinders = TaskQueue()
 
@@ -310,11 +306,11 @@ class CLI_Check():
         context.iteration(True)
 
         if not silent:
-            log('\nNon-Audio Files:')
+            logger.info('\nNon-Audio Files:')
 
             for input_file in input_files:
                 if input_file not in self.good_files:
-                    log(unquote_filename(beautify_uri(input_file)))
+                    logger.info(unquote_filename(beautify_uri(input_file)))
 
     def found_type(self, sound_file, mime):
         self.good_files.append(sound_file.uri)

--- a/soundconverter/error.py
+++ b/soundconverter/error.py
@@ -20,16 +20,13 @@
 # USA
 
 from gettext import gettext as _
+from soundconverter.utils import logger
 import sys
 
 
 class ErrorPrinter:
-
     def show_error(self, primary, secondary):
-        try:
-            sys.stderr.write(_('\n\nError: %s\n%s\n') % (primary, secondary))
-        except Exception:
-            pass
+        logger.error(_('%s\n%s\n') % (primary, secondary))
         sys.exit(1)
 
 
@@ -37,6 +34,7 @@ error_handler = ErrorPrinter()
 
 
 def set_error_handler(handler):
+    """Overwrite the error handler to, for example, show errors in a gtk dialog instead of the console"""
     global error_handler
     error_handler = handler
 

--- a/soundconverter/error.py
+++ b/soundconverter/error.py
@@ -26,7 +26,8 @@ import sys
 
 class ErrorPrinter:
     def show_error(self, primary, secondary):
-        logger.error(_('%s\n%s\n') % (primary, secondary))
+        logger.error(_('{}').format(primary))
+        logger.error(_('{}').format(secondary))
         sys.exit(1)
 
 

--- a/soundconverter/fileoperations.py
+++ b/soundconverter/fileoperations.py
@@ -77,9 +77,9 @@ def vfs_rename(original, newname):
     """Rename a gnomevfs file."""
     gforiginal = Gio.file_parse_name(original)
     gfnew = Gio.file_parse_name(newname)
-    debug('Creating folder \'%s\'?' % gfnew.get_parent().get_uri())
+    debug('Creating folder \'{}\'?'.format(gfnew.get_parent().get_uri()))
     if not gfnew.get_parent().query_exists(None):
-        debug('Creating folder: \'%s\'' % gfnew.get_parent().get_uri())
+        debug('Creating folder: \'{}\''.format(gfnew.get_parent().get_uri()))
         Gio.File.make_directory_with_parents(gfnew.get_parent(), None)
     gforiginal.move(gfnew, Gio.FileCopyFlags.NONE, None, None, None)
 

--- a/soundconverter/fileoperations.py
+++ b/soundconverter/fileoperations.py
@@ -26,7 +26,7 @@ import urllib.error
 import gi
 from gi.repository import Gio
 
-from soundconverter.utils import debug
+from soundconverter.utils import logger
 from soundconverter.error import show_error
 
 
@@ -77,9 +77,9 @@ def vfs_rename(original, newname):
     """Rename a gnomevfs file."""
     gforiginal = Gio.file_parse_name(original)
     gfnew = Gio.file_parse_name(newname)
-    debug('Creating folder \'{}\'?'.format(gfnew.get_parent().get_uri()))
+    logger.debug('Creating folder \'{}\'?'.format(gfnew.get_parent().get_uri()))
     if not gfnew.get_parent().query_exists(None):
-        debug('Creating folder: \'{}\''.format(gfnew.get_parent().get_uri()))
+        logger.debug('Creating folder: \'{}\''.format(gfnew.get_parent().get_uri()))
         Gio.File.make_directory_with_parents(gfnew.get_parent(), None)
     gforiginal.move(gfnew, Gio.FileCopyFlags.NONE, None, None, None)
 

--- a/soundconverter/formats.py
+++ b/soundconverter/formats.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# SoundConverter - GNOME application for converting between audio formats.
+# Copyright 2004 Lars Wirzenius
+# Copyright 2005-2017 Gautier Portet
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA
+
+from gettext import gettext as _
+from multiprocessing import cpu_count
+from gi.repository import Gio
+
+# add here any format you want to be read
+mime_whitelist = (
+    'audio/',
+    'video/',
+    'application/ogg',
+    'application/x-id3',
+    'application/x-ape',
+    'application/vnd.rn-realmedia',
+    'application/x-pn-realaudio',
+    'application/x-shockwave-flash',
+    'application/x-3gp',
+)
+
+filename_blacklist = (
+    '*.iso',
+)
+
+# custom filename patterns
+english_patterns = 'Artist Album Album-Artist Title Track Total Genre Date Year Timestamp DiscNumber DiscTotal Ext'
+
+# traductors: These are the custom filename patterns. Only if it makes sense.
+locale_patterns = _('Artist Album Album-Artist Title Track Total Genre Date Year Timestamp DiscNumber DiscTotal Ext')
+
+patterns_formats = (
+    '%(artist)s',
+    '%(album)s',
+    '%(album-artist)s',
+    '%(title)s',
+    '%(track-number)02d',
+    '%(track-count)02d',
+    '%(genre)s',
+    '%(date)s',
+    '%(year)s',
+    '%(timestamp)s',
+    '%(album-disc-number)d',
+    '%(album-disc-count)d',
+    '%(.target-ext)s',
+)
+
+# add english and locale
+custom_patterns = english_patterns + ' ' + locale_patterns
+# convert to list
+custom_patterns = ['{%s}' % p for p in custom_patterns.split()]
+# and finally to dict, thus removing doubles
+custom_patterns = dict(list(zip(custom_patterns, patterns_formats * 2)))
+
+locale_patterns_dict = dict(list(zip(
+    [p.lower() for p in english_patterns.split()],
+    ['{%s}' % p for p in locale_patterns.split()])))
+
+# Name and pattern for CustomFileChooser
+filepattern = (
+    (_('All files'), '*.*'),
+    ('MP3',          '*.mp3'),
+    ('Ogg Vorbis',   '*.ogg;*.oga'),
+    ('iTunes AAC ',  '*.m4a'),
+    ('Windows WAV',  '*.wav'),
+    ('AAC',          '*.aac'),
+    ('FLAC',         '*.flac'),
+    ('AC3',          '*.ac3')
+)
+
+
+mime_types = {
+    'vorbis': 'audio/x-vorbis', 'flac': 'audio/x-flac', 'wav': 'audio/x-wav',
+    'mp3': 'audio/mpeg', 'aac': 'audio/x-m4a'
+}
+
+
+def get_mime_type(t):
+    """Return the matching mime-type or None if it is not supported.
+    
+    Parameters
+    ----------
+        t : string
+            extension-type (like 'mp3') or mime-type (like 'audio/x-m4a')
+    """
+    if t not in mime_types.values():
+        # possibly a file extension
+        return mime_types.get(t, None)
+    else:
+        # already a mime string
+        return t
+
+
+def get_quality(ftype, value, mode='vbr', reverse=False):
+    """Map an integer between 0 and 6 to a proper quality value depending on target file type.
+
+    ftype of 'vorbis', 'aac', 'opus' or 'mp3',
+    value between 0 and 5,
+    mode one of 'cbr', 'abr' and 'vbr' for mp3
+
+    reverse is by default False. If True, this
+    function returns the original value-parameter
+    given a quality setting. Value becomes the
+    input for the quality then.
+    """
+    quality = {
+        'vorbis': (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),
+        'aac': (64, 96, 128, 192, 256, 320),
+        'opus': (48, 64, 96, 128, 160, 192),
+        'mp3': {
+            'cbr': (64, 96, 128, 192, 256, 320),
+            'abr': (64, 96, 128, 192, 256, 320),
+            'vbr': (9, 7, 5, 3, 1, 0),  # inverted !
+        }
+    }
+
+    # get 6-tuple of qualities
+    qualities = None
+    if ftype == 'mp3':
+        qualities = quality[ftype][mode]
+    else:
+        qualities = quality[ftype]
+
+    # return depending on function parameters
+    if reverse:
+        if type(value) == float:
+            # floats are inaccurate, search for close value
+            for i, q in enumerate(qualities):
+                if abs(value - q) < 0.01:
+                    return i
+        return qualities.index(value)
+    else:
+        return qualities[value]

--- a/soundconverter/formats.py
+++ b/soundconverter/formats.py
@@ -111,14 +111,17 @@ def get_mime_type(t):
 def get_quality(ftype, value, mode='vbr', reverse=False):
     """Map an integer between 0 and 6 to a proper quality value depending on target file type.
 
-    ftype of 'vorbis', 'aac', 'opus' or 'mp3',
-    value between 0 and 5,
-    mode one of 'cbr', 'abr' and 'vbr' for mp3
-
-    reverse is by default False. If True, this
-    function returns the original value-parameter
-    given a quality setting. Value becomes the
-    input for the quality then.
+    Parameters
+    ----------
+        ftype : string
+            'vorbis', 'aac', 'opus' or 'mp3',
+        value : number
+            between 0 and 5,
+        mode : string
+            one of 'cbr', 'abr' and 'vbr' for mp3
+        reverse : boolean
+            default False. If True, this function returns the original value-parameter
+            given a quality setting. Value becomes the input for the quality then.
     """
     quality = {
         'vorbis': (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),

--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -335,13 +335,13 @@ class TypeFinder(Pipeline):
         self.add_signal('typefind', 'have-type', self.have_type)
         self.silent = silent
 
-    def log(self, *args):
+    def log(self, msg):
         """Print a line to the console, but only when the TypeFinder itself is not set to silent.
 
         It can also be disabled with the -q command line option.
         """
         if not self.silent:
-            logger.info(*args)
+            logger.info(msg)
 
     def on_error(self, error):
         self.error = error

--- a/soundconverter/gstreamer.py
+++ b/soundconverter/gstreamer.py
@@ -228,7 +228,6 @@ class Pipeline(BackgroundTask):
         import threading
 
         t = message.type
-        logger.debug('received message of type "{}"'.format(t))
         if t == Gst.MessageType.ERROR:
             error, __ = message.parse_error()
             self.eos = True

--- a/soundconverter/namegenerator.py
+++ b/soundconverter/namegenerator.py
@@ -104,8 +104,7 @@ class TargetNameGenerator:
         root, ext = os.path.splitext(urllib.parse.urlparse(sound_file.uri).path)
 
         root = sound_file.base_path
-        basename, ext = os.path.splitext(
-            urllib.parse.unquote(sound_file.filename))
+        basename, ext = os.path.splitext(urllib.parse.unquote(sound_file.filename))
 
         # make sure basename contains only the filename
         basefolder, basename = os.path.split(basename)

--- a/soundconverter/queue.py
+++ b/soundconverter/queue.py
@@ -84,7 +84,7 @@ class TaskQueue(BackgroundTask):
     def started(self):
         """BackgroundTask setup callback."""
         num_tasks = len(self.waiting_tasks) + len(self.running_tasks)
-        logger.info('Queue start: %d tasks, %d thread(s).' % (num_tasks, self.jobs))
+        logger.info('Queue start: {} tasks, {} thread(s).'.format(num_tasks, self.jobs))
         self.count = 0
         self.paused = False
         self.finished_tasks = 0
@@ -93,7 +93,7 @@ class TaskQueue(BackgroundTask):
 
     def finished(self):
         """BackgroundTask finish callback."""
-        logger.info('Queue done in %.3fs (%s tasks)' % (time.time() - self.start_time, self.count))
+        logger.info('Queue done in %.3fs ({} tasks)'.format(time.time() - self.start_time, self.count))
         self.queue_ended()
         self.count = 0
         self.start_time = None

--- a/soundconverter/queue.py
+++ b/soundconverter/queue.py
@@ -49,8 +49,10 @@ class TaskQueue(BackgroundTask):
         self.start_time = None
         self.count = 0
         self.paused = False
-        self.jobs = settings['forced-jobs'] or settings['jobs']
-        self.jobs = self.jobs or settings['cpu-count']
+
+    def get_num_jobs(self):
+        """Return the number of jobs that should be run in parallel."""
+        return settings['forced-jobs'] or settings['jobs'] or settings['cpu-count']
 
     def add_task(self, task):
         """Add a task to the queue."""
@@ -66,7 +68,7 @@ class TaskQueue(BackgroundTask):
                 self.done()
             return
 
-        to_start = self.jobs - len(self.running_tasks)
+        to_start = self.get_num_jobs() - len(self.running_tasks)
         for _ in range(to_start):
             try:
                 task = self.waiting_tasks.pop(0)
@@ -84,7 +86,7 @@ class TaskQueue(BackgroundTask):
     def started(self):
         """BackgroundTask setup callback."""
         num_tasks = len(self.waiting_tasks) + len(self.running_tasks)
-        logger.info('Queue start: {} tasks, {} thread(s).'.format(num_tasks, self.jobs))
+        logger.info('Queue start: {} tasks, {} thread(s).'.format(num_tasks, self.get_num_jobs()))
         self.count = 0
         self.paused = False
         self.finished_tasks = 0

--- a/soundconverter/queue.py
+++ b/soundconverter/queue.py
@@ -93,7 +93,7 @@ class TaskQueue(BackgroundTask):
 
     def finished(self):
         """BackgroundTask finish callback."""
-        logger.info('Queue done in %.3fs ({} tasks)'.format(time.time() - self.start_time, self.count))
+        logger.info('Queue done in %.3fs (%d tasks)' % (time.time() - self.start_time, self.count))
         self.queue_ended()
         self.count = 0
         self.start_time = None

--- a/soundconverter/queue.py
+++ b/soundconverter/queue.py
@@ -22,7 +22,7 @@
 import time
 from soundconverter.task import BackgroundTask
 from soundconverter.settings import settings
-from soundconverter.utils import log
+from soundconverter.utils import logger
 
 
 class TaskQueue(BackgroundTask):
@@ -83,8 +83,8 @@ class TaskQueue(BackgroundTask):
 
     def started(self):
         """BackgroundTask setup callback."""
-        log('Queue start: %d tasks, %d thread(s).' % (
-            len(self.waiting_tasks) + len(self.running_tasks), self.jobs))
+        num_tasks = len(self.waiting_tasks) + len(self.running_tasks)
+        logger.info('Queue start: %d tasks, %d thread(s).' % (num_tasks, self.jobs))
         self.count = 0
         self.paused = False
         self.finished_tasks = 0
@@ -93,7 +93,7 @@ class TaskQueue(BackgroundTask):
 
     def finished(self):
         """BackgroundTask finish callback."""
-        log('Queue done in %.3fs (%s tasks)' % (time.time() - self.start_time, self.count))
+        logger.info('Queue done in %.3fs (%s tasks)' % (time.time() - self.start_time, self.count))
         self.queue_ended()
         self.count = 0
         self.start_time = None

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -39,7 +39,7 @@ from soundconverter.soundfile import SoundFile
 from soundconverter.settings import locale_patterns_dict, custom_patterns, filepattern, settings, get_quality
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.queue import TaskQueue
-from soundconverter.utils import logger, debug, idle
+from soundconverter.utils import logger, idle
 from soundconverter.error import show_error, set_error_handler
 
 # Names of columns in the file list
@@ -190,7 +190,7 @@ class FileList:
 
     def found_type(self, sound_file, mime):
         ext = os.path.splitext(sound_file.filename)[1]
-        debug('mime:', ext, mime)
+        logger.debug('mime: {} {}'.format(ext, mime))
         self.good_files.append(sound_file.uri)
 
     @idle
@@ -368,8 +368,9 @@ class FileList:
         self.window.progressbarstatus.hide()
         self.files_to_add = None
         end_t = time.time()
-        debug('Added {} files in %.2fs (scan %.2fs, add %.2fs)'.format(
-            len(files), end_t - start_t, scan_t - start_t, end_t-scan_t))
+        logger.debug('Added %d files in %.2fs (scan %.2fs, add %.2fs)' % (
+            len(files), end_t - start_t, scan_t - start_t, end_t-scan_t)
+        )
 
     def typefinder_queue_ended(self):
         if not self.waiting_files:
@@ -1185,7 +1186,7 @@ class SoundConverterWindow(GladeWindow):
         return widget
 
     def close(self, *args):
-        debug('closing…')
+        logger.debug('closing…')
         self.filelist.abort()
         self.converter.abort()
         self.widget.hide()

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -39,7 +39,7 @@ from soundconverter.soundfile import SoundFile
 from soundconverter.settings import locale_patterns_dict, custom_patterns, filepattern, settings, get_quality
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.queue import TaskQueue
-from soundconverter.utils import log, debug, idle
+from soundconverter.utils import logger, debug, idle
 from soundconverter.error import show_error, set_error_handler
 
 # Names of columns in the file list
@@ -228,7 +228,7 @@ class FileList:
                 return
             info = Gio.file_parse_name(uri).query_file_type(Gio.FileMonitorFlags.NONE, None)
             if info == Gio.FileType.DIRECTORY:
-                log('walking: \'%s\'' % uri)
+                logger.info('walking: \'%s\'' % uri)
                 if len(uris) == 1:
                     # if only one folder is passed to the function,
                     # use its parent as base path.
@@ -264,7 +264,7 @@ class FileList:
             base += '/'
 
         scan_t = time.time()
-        log('analysing file integrity')
+        logger.info('analysing file integrity')
         self.files_to_add = len(files)
 
         # self.good_files will be populated
@@ -283,7 +283,7 @@ class FileList:
         self.typefinders.start()
 
         self.window.set_status('{}'.format(_('Adding Files…')))
-        log('adding: %d files' % len(files))
+        logger.info('adding: %d files' % len(files))
 
         # show progress and enable GTK main loop iterations
         # so that the ui stays responsive
@@ -324,7 +324,7 @@ class FileList:
                 invalid_files += 1
                 continue
             if sound_file.uri in self.filelist:
-                log('file already present: \'%s\'' % sound_file.uri)
+                logger.info('file already present: \'%s\'' % sound_file.uri)
                 continue
             self.append_file(sound_file)
 
@@ -349,7 +349,7 @@ class FileList:
                 # there is a single picture in a folder of hundreds of sound files).
                 # Show an error if this skipped file has a soundfile extension,
                 # otherwise don't bother the user.
-                log(invalid_files, 'of', len(files), 'files were not added to the list')
+                logger.info('%d of %d files were not added to the list' % (invalid_files, len(files)), len(files))
                 if broken_audiofiles > 0:
                     show_error(
                         ngettext(
@@ -567,7 +567,7 @@ class PreferencesDialog(GladeWindow):
                 found_profile = True
         if not found_profile and stored_profile:
             # reset default output
-            log('Cannot find audio profile "%s", resetting to default output.'
+            logger.info('Cannot find audio profile "%s", resetting to default output.'
                 % stored_profile)
             self.settings.set_string('audio-profile', '')
             self.gstprofile.set_active(0)

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -36,7 +36,9 @@ from soundconverter.fileoperations import filename_to_uri, beautify_uri, unquote
 from soundconverter.gstreamer import ConverterQueue, available_elements, \
     TypeFinder, audio_profiles_list, audio_profiles_dict
 from soundconverter.soundfile import SoundFile
-from soundconverter.settings import locale_patterns_dict, custom_patterns, filepattern, settings, get_quality
+from soundconverter.settings import settings, get_gio_settings
+from soundconverter.formats import get_quality
+from soundconverter.formats import locale_patterns_dict, custom_patterns, filepattern
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.queue import TaskQueue
 from soundconverter.utils import logger, idle
@@ -470,7 +472,7 @@ class PreferencesDialog(GladeWindow):
     ]
 
     def __init__(self, builder, parent):
-        self.settings = Gio.Settings(schema='org.soundconverter')
+        self.settings = get_gio_settings()
         GladeWindow.__init__(self, builder)
 
         self.dialog = builder.get_object('prefsdialog')
@@ -669,7 +671,7 @@ class PreferencesDialog(GladeWindow):
 
         self.force_mono.set_active(self.settings.get_boolean('force-mono'))
 
-        self.jobs.set_active(self.settings.get_int('limit-jobs'))
+        self.jobs.set_active(self.settings.get_boolean('limit-jobs'))
         self.jobs_spinbutton.set_value(self.settings.get_int('number-of-jobs'))
 
         self.update_jobs()
@@ -827,7 +829,7 @@ class PreferencesDialog(GladeWindow):
             self.settings.get_string('output-mime-type') == 'audio/x-vorbis')
 
         self.sensitive_widgets['jobs_spinbutton'].set_sensitive(
-            self.settings.get_int('limit-jobs'))
+            self.settings.get_boolean('limit-jobs'))
 
         if self.settings.get_string('output-mime-type') == 'gst-profile':
             self.sensitive_widgets['resample_hbox'].set_sensitive(False)
@@ -1058,7 +1060,7 @@ class PreferencesDialog(GladeWindow):
         self.resample_rate.set_sensitive(rstoggle.get_active())
 
     def on_jobs_toggled(self, jtoggle):
-        self.settings.set_int('limit-jobs', jtoggle.get_active())
+        self.settings.set_boolean('limit-jobs', jtoggle.get_active())
         self.jobs_spinbutton.set_sensitive(jtoggle.get_active())
         self.update_jobs()
 
@@ -1067,7 +1069,7 @@ class PreferencesDialog(GladeWindow):
         self.update_jobs()
 
     def update_jobs(self):
-        if self.settings.get_int('limit-jobs'):
+        if self.settings.get_boolean('limit-jobs'):
             settings['jobs'] = self.settings.get_int('number-of-jobs')
         else:
             settings['jobs'] = None

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -107,7 +107,7 @@ class MsgAreaErrorDialog_:
 
     def show_exception(self, exception):
         self.show(
-            '<b>%s</b>' % GLib.markup_escape_text(exception.primary),
+            '<b>{}</b>'.format(GLib.markup_escape_text(exception.primary)),
             exception.secondary
         )
 
@@ -228,7 +228,7 @@ class FileList:
                 return
             info = Gio.file_parse_name(uri).query_file_type(Gio.FileMonitorFlags.NONE, None)
             if info == Gio.FileType.DIRECTORY:
-                logger.info('walking: \'%s\'' % uri)
+                logger.info('walking: \'{}\''.format(uri))
                 if len(uris) == 1:
                     # if only one folder is passed to the function,
                     # use its parent as base path.
@@ -283,7 +283,7 @@ class FileList:
         self.typefinders.start()
 
         self.window.set_status('{}'.format(_('Adding Files…')))
-        logger.info('adding: %d files' % len(files))
+        logger.info('adding: {} files'.format(len(files)))
 
         # show progress and enable GTK main loop iterations
         # so that the ui stays responsive
@@ -324,7 +324,7 @@ class FileList:
                 invalid_files += 1
                 continue
             if sound_file.uri in self.filelist:
-                logger.info('file already present: \'%s\'' % sound_file.uri)
+                logger.info('file already present: \'{}\''.format(sound_file.uri))
                 continue
             self.append_file(sound_file)
 
@@ -349,7 +349,7 @@ class FileList:
                 # there is a single picture in a folder of hundreds of sound files).
                 # Show an error if this skipped file has a soundfile extension,
                 # otherwise don't bother the user.
-                logger.info('%d of %d files were not added to the list' % (invalid_files, len(files)), len(files))
+                logger.info('{} of {} files were not added to the list'.format(invalid_files, len(files)), len(files))
                 if broken_audiofiles > 0:
                     show_error(
                         ngettext(
@@ -368,7 +368,7 @@ class FileList:
         self.window.progressbarstatus.hide()
         self.files_to_add = None
         end_t = time.time()
-        debug('Added %d files in %.2fs (scan %.2fs, add %.2fs)' % (
+        debug('Added {} files in %.2fs (scan %.2fs, add %.2fs)'.format(
             len(files), end_t - start_t, scan_t - start_t, end_t-scan_t))
 
     def typefinder_queue_ended(self):
@@ -433,7 +433,7 @@ class GladeWindow(object):
         """Allow direct use of window widget."""
         widget = GladeWindow.builder.get_object(attribute)
         if widget is None:
-            raise AttributeError('Widget \'%s\' not found' % attribute)
+            raise AttributeError('Widget \'{}\' not found'.format(attribute))
         self.__dict__[attribute] = widget  # cache result
         return widget
 
@@ -547,7 +547,7 @@ class PreferencesDialog(GladeWindow):
         # desactivate output if encoder plugin is not present
         widget = self.output_mime_type
         model = widget.get_model()
-        assert len(model) == len(widgets), 'model:%d widgets:%d' % (len(model), len(widgets))
+        assert len(model) == len(widgets), 'model:{} widgets:{}'.format(len(model), len(widgets))
 
         if not self.gstprofile.get_model().get_n_columns():
             self.gstprofile.set_model(Gtk.ListStore(str))
@@ -561,7 +561,7 @@ class PreferencesDialog(GladeWindow):
         stored_profile = self.settings.get_string('audio-profile')
         for i, profile in enumerate(audio_profiles_list):
             description, extension, pipeline = profile
-            self.gstprofile.get_model().append(['%s (.%s)' % (description, extension)])
+            self.gstprofile.get_model().append(['{} (.{})'.format(description, extension)])
             if description == stored_profile:
                 self.gstprofile.set_active(i)
                 found_profile = True
@@ -714,9 +714,9 @@ class PreferencesDialog(GladeWindow):
 
         if bitrate:
             if aprox:
-                return '~%d kbps' % bitrate
+                return '~{} kbps'.format(bitrate)
             else:
-                return '%d kbps' % bitrate
+                return '{} kbps'.format(bitrate)
         else:
             return 'N/A'
 
@@ -751,7 +751,7 @@ class PreferencesDialog(GladeWindow):
 
         self.example.set_markup(s)
 
-        markup = '<small>%s</small>' % (_('Target bitrate: %s') % self.get_bitrate_from_settings())
+        markup = '<small>{}</small>'.format(_('Target bitrate: %s') % self.get_bitrate_from_settings())
         self.aprox_bitrate.set_markup(markup)
 
     def get_output_suffix(self):
@@ -1123,7 +1123,7 @@ class SoundConverterWindow(GladeWindow):
 
         # TODO: get all (gstreamer) knew files
         for files in filepattern:
-            self.store.append(['%s (%s)' % (files[0], files[1])])
+            self.store.append(['{} ({})'.format(files[0], files[1])])
 
         self.combo.set_active(0)
         self.addfolderchooser.set_extra_widget(self.combo)
@@ -1151,7 +1151,7 @@ class SoundConverterWindow(GladeWindow):
         # TODO: get all (gstreamer) knew files
         for files in filepattern:
             self.pattern.append(files[1])
-            self.addfile_store.append(['%s (%s)' % (files[0], files[1])])
+            self.addfile_store.append(['{} ({})'.format(files[0], files[1])])
 
         self.addfile_combo.set_active(0)
         self.addchooser.set_extra_widget(self.addfile_combo)
@@ -1180,7 +1180,7 @@ class SoundConverterWindow(GladeWindow):
         """Allow direct use of window widget."""
         widget = self.builder.get_object(attribute)
         if widget is None:
-            raise AttributeError('Widget \'%s\' not found' % attribute)
+            raise AttributeError('Widget \'{}\' not found'.format(attribute))
         self.__dict__[attribute] = widget  # cache result
         return widget
 
@@ -1427,7 +1427,7 @@ class SoundConverterWindow(GladeWindow):
 
         if self.converter.paused:
             self.progressbar.set_text(_('Paused'))
-            self.widget.set_title('%s - %s' % (_('SoundConverter'), _('Paused')))
+            self.widget.set_title('{} - {}'.format(_('SoundConverter'), _('Paused')))
             return
 
         fraction = min(max(fraction, 0.0), 1.0)
@@ -1449,7 +1449,7 @@ class SoundConverterWindow(GladeWindow):
             self.progressbar.set_text(remaining)
             self.progressbar.set_show_text(True)
             self.progress_time = time.time()
-            self.widget.set_title('%s - %s' % (_('SoundConverter'), remaining))
+            self.widget.set_title('{} - {}'.format(_('SoundConverter'), remaining))
 
     def set_status(self, text=None, ready=True):
         if not text:

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -368,8 +368,10 @@ class FileList:
         self.window.progressbarstatus.hide()
         self.files_to_add = None
         end_t = time.time()
-        logger.debug('Added %d files in %.2fs (scan %.2fs, add %.2fs)' % (
-            len(files), end_t - start_t, scan_t - start_t, end_t-scan_t)
+        logger.debug(
+            'Added %d files in %.2fs (scan %.2fs, add %.2fs)' % (
+                len(files), end_t - start_t, scan_t - start_t, end_t - scan_t
+            )
         )
 
     def typefinder_queue_ended(self):

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -468,7 +468,7 @@ class PreferencesDialog(GladeWindow):
     ]
 
     def __init__(self, builder, parent):
-        self.settings = Gio.Settings('org.soundconverter')
+        self.settings = Gio.Settings(schema='org.soundconverter')
         GladeWindow.__init__(self, builder)
 
         self.dialog = builder.get_object('prefsdialog')

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -34,7 +34,7 @@ from gi.repository import GObject, Gtk, Gio, Gdk, GLib
 
 from soundconverter.fileoperations import filename_to_uri, beautify_uri, unquote_filename, vfs_walk, vfs_exists
 from soundconverter.gstreamer import ConverterQueue, available_elements, \
-    TypeFinder, TagReader, audio_profiles_list, audio_profiles_dict
+    TypeFinder, audio_profiles_list, audio_profiles_dict
 from soundconverter.soundfile import SoundFile
 from soundconverter.settings import locale_patterns_dict, custom_patterns, filepattern, settings, get_quality
 from soundconverter.namegenerator import TargetNameGenerator

--- a/soundconverter/ui.py
+++ b/soundconverter/ui.py
@@ -129,7 +129,7 @@ class FileList:
 
         self.widget = builder.get_object('filelist')
         self.widget.props.fixed_height_mode = True
-        self.sortedmodel = Gtk.TreeModelSort(self.model)
+        self.sortedmodel = Gtk.TreeModelSort(model=self.model)
         self.widget.set_model(self.sortedmodel)
         self.sortedmodel.set_sort_column_id(4, Gtk.SortType.ASCENDING)
         self.widget.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
@@ -351,7 +351,7 @@ class FileList:
                 # there is a single picture in a folder of hundreds of sound files).
                 # Show an error if this skipped file has a soundfile extension,
                 # otherwise don't bother the user.
-                logger.info('{} of {} files were not added to the list'.format(invalid_files, len(files)), len(files))
+                logger.info('{} of {} files were not added to the list'.format(invalid_files, len(files)))
                 if broken_audiofiles > 0:
                     show_error(
                         ngettext(
@@ -507,10 +507,14 @@ class PreferencesDialog(GladeWindow):
         w.set_active(True)
 
         self.target_folder_chooser = Gtk.FileChooserDialog(
-            _('Add Folder…'),
-            self.dialog, Gtk.FileChooserAction.SELECT_FOLDER,
-            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+            title=_('Add Folder…'),
+            transient_for=self.dialog,
+            action=Gtk.FileChooserAction.SELECT_FOLDER
         )
+
+        self.target_folder_chooser.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.target_folder_chooser.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+
         self.target_folder_chooser.set_select_multiple(False)
         self.target_folder_chooser.set_local_only(False)
 
@@ -1109,13 +1113,14 @@ class SoundConverterWindow(GladeWindow):
         self.existsdialog.apply_to_all = builder.get_object('apply_to_all')
 
         self.addfolderchooser = Gtk.FileChooserDialog(
-            _('Add Folder…'),
-            self.widget, Gtk.FileChooserAction.SELECT_FOLDER,
-            (
-                Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN,
-                Gtk.ResponseType.OK
-            )
+            title=_('Add Folder…'),
+            transient_for=self.widget,
+            action=Gtk.FileChooserAction.SELECT_FOLDER
         )
+
+        self.addfolderchooser.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.addfolderchooser.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+
         self.addfolderchooser.set_select_multiple(True)
         self.addfolderchooser.set_local_only(False)
 
@@ -1134,13 +1139,14 @@ class SoundConverterWindow(GladeWindow):
         self.addfolderchooser.set_extra_widget(self.combo)
 
         self.addchooser = Gtk.FileChooserDialog(
-            _('Add Files…'),
-            self.widget, Gtk.FileChooserAction.OPEN,
-            (
-                Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN,
-                Gtk.ResponseType.OK
-            )
+            title=_('Add Files…'),
+            transient_for=self.widget,
+            action=Gtk.FileChooserAction.OPEN
         )
+
+        self.addchooser.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.addchooser.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+
         self.addchooser.set_select_multiple(True)
         self.addchooser.set_local_only(False)
 

--- a/soundconverter/utils.py
+++ b/soundconverter/utils.py
@@ -57,22 +57,6 @@ def update_verbosity():
         logger.setLevel(logging.INFO)
 
 
-def log(*args):
-    """Display a message.
-    
-    Can be disabled with the 'quiet' option (-q)
-    """
-    logger.info(' '.join([str(msg) for msg in args]))
-
-
-def debug(*args):
-    """Display a debug message.
-
-    Only when activated by the 'debug' option
-    """
-    logger.debug(' '.join([str(msg) for msg in args]))
-
-
 def idle(func):
     def callback(*args, **kwargs):
         GLib.idle_add(func, *args, **kwargs)

--- a/soundconverter/utils.py
+++ b/soundconverter/utils.py
@@ -21,7 +21,7 @@
 
 # logging & debugging
 
-from .settings import settings
+from soundconverter.settings import settings
 from gi.repository import GLib
 import logging
 

--- a/soundconverter/utils.py
+++ b/soundconverter/utils.py
@@ -35,8 +35,9 @@ class Formatter(logging.Formatter):
             color = {
                 logging.WARNING: 33,
                 logging.ERROR: 31,
+                logging.FATAL: 31,
                 logging.DEBUG: 36
-            }[record.levelno]
+            }.get(record.levelno, 0)
             self._style._fmt = '\033[{}m%(levelname)s\033[0m: %(msg)s'.format(color)
         return super().format(record)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+
+"""Sets up soundconverter for the tests and runs them."""
+
+
+import sys
+import gi
+gi.require_version('Gst', '1.0')
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gst, Gio, Gtk, GLib
+Gst.init([None] + [a for a in sys.argv[1:] if '-gst' in a])
+
+from soundconverter.settings import set_gio_settings
+from soundconverter.ui import win, gtk_iteration
+
+# don't overwrite the users settings during tests
+backend = Gio.memory_settings_backend_new()
+gio_settings = Gio.Settings.new_with_backend('org.soundconverter', backend)
+set_gio_settings(gio_settings)
+
+# tests will control gtk main iterations
+Gtk.main = gtk_iteration
+Gtk.main_quit = lambda: None
+
+# import all the tests and run them
+import unittest
+from testcases.integration import *
+from testcases.names import *
+from testcases.format import *
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testcases/format.py
+++ b/tests/testcases/format.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from soundconverter.formats import get_mime_type
+
+
+class Format(unittest.TestCase):
+    def test_get_mime_type(self):
+        self.assertEqual(get_mime_type('mp3'), 'audio/mpeg')
+        self.assertEqual(get_mime_type('audio/x-m4a'), 'audio/x-m4a')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testcases/format.py
+++ b/tests/testcases/format.py
@@ -2,13 +2,19 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from soundconverter.formats import get_mime_type
+from soundconverter.formats import get_mime_type, get_quality
 
 
 class Format(unittest.TestCase):
     def test_get_mime_type(self):
         self.assertEqual(get_mime_type('mp3'), 'audio/mpeg')
         self.assertEqual(get_mime_type('audio/x-m4a'), 'audio/x-m4a')
+
+    def test_get_quality(self):
+        self.assertEqual(get_quality('mp3', 0, 'cbr'), 64)
+        self.assertEqual(get_quality('aac', 1, 'thetgdfgsfd'), 96)
+        self.assertEqual(get_quality('aac', 256, reverse=True), 4)
+        self.assertEqual(get_quality('mp3', 320, mode='abr', reverse=True), 5)
 
 
 if __name__ == "__main__":

--- a/tests/testcases/integration.py
+++ b/tests/testcases/integration.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+
+"""Tests that start soundconverter and try to convert files."""
+
+
+import unittest
+from unittest.mock import patch
+import os
+import sys
+import shutil
+import urllib.parse
+from gi.repository import Gio, Gtk
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
+
+from soundconverter.settings import settings, get_gio_settings
+from soundconverter.soundfile import SoundFile
+from soundconverter.fileoperations import filename_to_uri
+from soundconverter.ui import win, gtk_iteration
+
+from util import reset_settings
+
+
+def launch(argv=[]):
+    """Start the soundconverter with the command line argument array argv.
+    
+    Make sure to run the `make` command first in your terminal.
+    """
+    testargs = sys.argv.copy()[:2]
+    testargs += argv
+    with patch.object(sys, 'argv', testargs):
+        spec = spec_from_loader("launcher", SourceFileLoader("launcher", "bin/soundconverter"))
+        spec.loader.exec_module(module_from_spec(spec))
+
+
+def quote(ss):
+    if isinstance(ss, str):
+        ss = ss.encode('utf-8')
+    return urllib.parse.quote(ss)
+
+
+class Batch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.makedirs("tests/tmp", exist_ok=True)
+
+    def tearDown(self):
+        reset_settings()
+        if os.path.isdir("tests/tmp/"):
+            shutil.rmtree("tests/tmp")
+
+    def testNonRecursiveWithFolder(self):
+        # it should exit with code 1, because no files are supplied
+        with self.assertRaises(SystemExit) as cm:
+            launch(["-b", "-q", "tests/test data/empty"])
+        the_exception = cm.exception
+        self.assertEqual(the_exception.code, 1)
+
+    def testRecursiveEmpty(self):
+        # it should exit with code 2, because files are found but they
+        # are not audiofiles
+        with self.assertRaises(SystemExit) as cm:
+            launch(["-b", "-r", "-q", "tests/test data/empty"])
+        the_exception = cm.exception
+        self.assertEqual(the_exception.code, 2)
+
+    def testRecursiveAudio(self):
+        # it should convert
+        launch([
+            "-b", "tests/test data/audio",
+            "-r",
+            "-q",
+            "-o", "tests/tmp",
+            "-m", "mp3",
+            "-s", ".mp3"
+            ])
+        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/a.mp3"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.mp3"))
+
+    def testMultiplePaths(self):
+        # it should convert
+        launch([
+            "-b", "tests/test data/audio", "tests/test data/audio/a.wav", "tests/test data/empty",
+            "-r",
+            "-q",
+            "-o", "tests/tmp",
+            "-m", "audio/x-m4a",
+            "-s", ".m4a"
+            ])
+        # The batch mode behaves like the cp command:
+        # - input is a folder, has to provide -r, output is a folder
+        # - input is a file, output is a file
+        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/a.m4a"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.m4a"))
+        self.assertTrue(os.path.isfile("tests/tmp/a.m4a"))
+
+
+class GUI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if os.path.isdir("tests/tmp/"):
+            shutil.rmtree("tests/tmp")
+        os.makedirs("tests/tmp", exist_ok=True)
+
+    def tearDown(self):
+        win[0].close()
+        reset_settings()
+        if os.path.isdir("tests/tmp/"):
+            shutil.rmtree("tests/tmp")
+
+    def testConversion(self):
+        launch(["tests/test data/audio/a.wav", "tests/test data/audio/strângë chàrs фズ.wav",
+                "tests/test data/audio/", "tests/test data/empty"])
+        window = win[0]
+
+        # check if directory is read correctly
+        expectation = ["tests/test data/audio/a.wav", "tests/test data/audio/strângë chàrs фズ.wav",
+                       "tests/test data/audio/b/c.mp3"]
+        self.assertCountEqual([filename_to_uri(path) for path in expectation], win[0].filelist.filelist)
+
+        # setup for conversion
+        window.prefs.change_mime_type('audio/ogg; codecs=opus')
+        get_gio_settings().set_boolean('create-subfolders', False)
+        get_gio_settings().set_boolean('same-folder-as-input', False)
+        get_gio_settings().set_string('selected-folder', os.path.abspath("tests/tmp"))
+        get_gio_settings().set_int('name-pattern-index', 0)
+        get_gio_settings().set_boolean('replace-messy-chars', True)
+        get_gio_settings().set_boolean('delete-original', False)
+
+        # start conversion
+        window.on_convert_button_clicked()
+
+        # wait for the assertions until all files are converted
+        while window.converter.finished_tasks < len(expectation):
+            # as Gtk.main is replaced by gtk_iteration, the unittests
+            # are responsible about when soundconverter continues
+            # to work on the conversions and updating the GUI
+            gtk_iteration()
+
+        print(os.getcwd())
+        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/a.opus"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/strange_chars_.opus"))
+        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.opus"))
+        # no duplicates in the GUI:
+        self.assertFalse(os.path.isfile("tests/tmp/a.opus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testcases/names.py
+++ b/tests/testcases/names.py
@@ -1,68 +1,24 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
+
+"""Test filename handling."""
+
+
 import unittest
-from unittest.mock import patch
 import os
-import sys
-import shutil
 from urllib.parse import unquote
-import urllib.request
 import urllib.parse
 import urllib.error
-import time
+from gi.repository import Gst, Gio
 
-import gi
-gi.require_version('Gst', '1.0')
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gst, Gio, Gtk, GLib
-Gst.init([None] + [a for a in sys.argv[1:] if '-gst' in a])
-
-import inspect
-from soundconverter.settings import settings, set_gio_settings, get_gio_settings
+from soundconverter.settings import settings
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.soundfile import SoundFile
 from soundconverter.fileoperations import filename_to_uri, unquote_filename, beautify_uri
 from soundconverter.batch import prepare_files_list
-from soundconverter.ui import win, gtk_iteration
 
-from importlib.util import spec_from_loader, module_from_spec
-from importlib.machinery import SourceFileLoader
-
-DEFAULT_SETTINGS = settings.copy()
-
-backend = Gio.memory_settings_backend_new()
-gio_settings = Gio.Settings.new_with_backend('org.soundconverter', backend)
-set_gio_settings(gio_settings)
-
-# tests will control gtk main iterations
-Gtk.main = gtk_iteration
-Gtk.main_quit = lambda: None
-
-
-def launch(argv=[]):
-    """Start the soundconverter with the command line argument array argv.
-    
-    Make sure to run the `make` command first in your terminal.
-    """
-    testargs = sys.argv.copy()[:2]
-    testargs += argv
-    with patch.object(sys, 'argv', testargs):
-        spec = spec_from_loader("launcher", SourceFileLoader("launcher", "bin/soundconverter"))
-        spec.loader.exec_module(module_from_spec(spec))
-
-
-def reset_settings():
-    """Reset the global settings to their initial state."""
-    global settings
-    # convert to list otherwise del won't work
-    for key in list(settings.keys()):
-        if key in DEFAULT_SETTINGS:
-            settings[key] = DEFAULT_SETTINGS[key]
-        else:
-            del settings[key]
-    # batch tests assume that recursive is off by default:
-    assert (("recursive" not in settings) or (not settings["recursive"]))
+from util import reset_settings
 
 
 def quote(ss):
@@ -121,114 +77,6 @@ class PrepareFilesList(unittest.TestCase):
         self.assertEqual(result, expectation)
 
 
-class Batch(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.makedirs("tests/tmp", exist_ok=True)
-
-    def tearDown(self):
-        reset_settings()
-        if os.path.isdir("tests/tmp/"):
-            shutil.rmtree("tests/tmp")
-
-    def testNonRecursiveWithFolder(self):
-        # it should exit with code 1, because no files are supplied
-        with self.assertRaises(SystemExit) as cm:
-            launch(["-b", "-q", "tests/test data/empty"])
-        the_exception = cm.exception
-        self.assertEqual(the_exception.code, 1)
-
-    def testRecursiveEmpty(self):
-        # it should exit with code 2, because files are found but they
-        # are not audiofiles
-        with self.assertRaises(SystemExit) as cm:
-            launch(["-b", "-r", "-q", "tests/test data/empty"])
-        the_exception = cm.exception
-        self.assertEqual(the_exception.code, 2)
-
-    def testRecursiveAudio(self):
-        # it should convert
-        launch([
-            "-b", "tests/test data/audio",
-            "-r",
-            "-q",
-            "-o", "tests/tmp",
-            "-m", "mp3",
-            "-s", ".mp3"
-            ])
-        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/a.mp3"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.mp3"))
-
-    def testMultiplePaths(self):
-        # it should convert
-        launch([
-            "-b", "tests/test data/audio", "tests/test data/audio/a.wav", "tests/test data/empty",
-            "-r",
-            "-q",
-            "-o", "tests/tmp",
-            "-m", "audio/x-m4a",
-            "-s", ".m4a"
-            ])
-        # The batch mode behaves like the cp command:
-        # - input is a folder, has to provide -r, output is a folder
-        # - input is a file, output is a file
-        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/a.m4a"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.m4a"))
-        self.assertTrue(os.path.isfile("tests/tmp/a.m4a"))
-
-
-class GUI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        if os.path.isdir("tests/tmp/"):
-            shutil.rmtree("tests/tmp")
-        os.makedirs("tests/tmp", exist_ok=True)
-
-    def tearDown(self):
-        win[0].close()
-        reset_settings()
-        if os.path.isdir("tests/tmp/"):
-            shutil.rmtree("tests/tmp")
-
-    def testConversion(self):
-        launch(["-q", "tests/test data/audio/a.wav", "tests/test data/audio/strângë chàrs фズ.wav",
-                "tests/test data/audio/", "tests/test data/empty"])
-        window = win[0]
-
-        # check if directory is read correctly
-        expectation = ["tests/test data/audio/a.wav", "tests/test data/audio/strângë chàrs фズ.wav",
-                       "tests/test data/audio/b/c.mp3"]
-        self.assertCountEqual([filename_to_uri(path) for path in expectation], win[0].filelist.filelist)
-
-        # setup for conversion
-        window.prefs.change_mime_type('audio/ogg; codecs=opus')
-        get_gio_settings().set_boolean('create-subfolders', False)
-        get_gio_settings().set_boolean('same-folder-as-input', False)
-        get_gio_settings().set_string('selected-folder', os.path.abspath("tests/tmp"))
-        get_gio_settings().set_int('name-pattern-index', 0)
-        get_gio_settings().set_boolean('replace-messy-chars', True)
-        get_gio_settings().set_boolean('delete-original', False)
-
-        # start conversion
-        window.on_convert_button_clicked()
-
-        # wait for the assertions until all files are converted
-        while window.converter.finished_tasks < len(expectation):
-            # as Gtk.main is replaced by gtk_iteration, the unittests
-            # are responsible about when soundconverter continues
-            # to work on the conversions and updating the GUI
-            gtk_iteration()
-
-        self.assertTrue(os.path.isdir("tests/tmp/audio/"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/a.opus"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/strange_chars_.opus"))
-        self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.opus"))
-        # no duplicates in the GUI:
-        self.assertFalse(os.path.isfile("tests/tmp/a.opus"))
-
-
 class TargetNameGeneratorTestCases(unittest.TestCase):
     def setUp(self):
         self.g = TargetNameGenerator()
@@ -261,6 +109,8 @@ class TargetNameGeneratorTestCases(unittest.TestCase):
         self.assertEqual(beautify_uri('file://baz%20qux'), 'baz qux')
 
     def test_safe_name(self):
+        # the "test data" folder has the space in it on purpose for this spec
+
         # 1. path doesn't exist at all
         self.assertEqual(self.g.safe_name('/b äz/quズx/foo.mp3'), '/b_az/qux/foo.mp3')
         self.assertEqual(self.g.safe_name('/baズz/qux'), '/baz/qux')

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -31,20 +31,12 @@ from importlib.machinery import SourceFileLoader
 
 DEFAULT_SETTINGS = settings.copy()
 
-gio_settings = Gio.Settings('org.soundconverter')
-
-gio_settings_original_mapping = {key: gio_settings.get_value(key) for key in gio_settings.keys()}
-
-gio_settings.set_boolean('delete-original', False)
-
-for key in gio_settings_original_mapping:
-    gio_settings.set_value(key, gio_settings_original_mapping[key])
-
-print(gio_settings.get_value('delete-original'))
-
 # tests will control gtk main iterations
 Gtk.main = gtk_iteration
 Gtk.main_quit = lambda: None
+
+gio_settings = Gio.Settings(schema='org.soundconverter')
+gio_settings_original_mapping = {key: gio_settings.get_value(key) for key in gio_settings.keys()}
 
 
 def launch(argv=[]):
@@ -52,7 +44,6 @@ def launch(argv=[]):
     
     Make sure to run the `make` command first in your terminal.
     """
-    exit()
     testargs = sys.argv.copy()[:2]
     testargs += argv
     with patch.object(sys, 'argv', testargs):
@@ -194,6 +185,14 @@ class GUI(unittest.TestCase):
             shutil.rmtree("tests/tmp")
         os.makedirs("tests/tmp", exist_ok=True)
 
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the settings that can be configured over the UI to the users specified values."""
+        for key in gio_settings_original_mapping:
+            gio_settings.set_value(key, gio_settings_original_mapping[key])
+        # apparently set_value needs some time to get applied
+        time.sleep(0.1)
+
     def tearDown(self):
         win[0].close()
         reset_settings()
@@ -217,6 +216,7 @@ class GUI(unittest.TestCase):
         window.prefs.settings.set_string('selected-folder', os.path.abspath("tests/tmp"))
         window.prefs.settings.set_int('name-pattern-index', 0)
         window.prefs.settings.set_boolean('replace-messy-chars', True)
+        window.prefs.settings.set_boolean('delete-original', False)
 
         # start conversion
         window.on_convert_button_clicked()

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -16,7 +16,7 @@ import gi
 gi.require_version('Gst', '1.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gst, Gio, Gtk, GLib
-Gst.init([a for a in sys.argv[1:] if '-gst' in a])
+Gst.init([None] + [a for a in sys.argv[1:] if '-gst' in a])
 
 from soundconverter.settings import settings
 from soundconverter.namegenerator import TargetNameGenerator
@@ -173,6 +173,9 @@ class Batch(unittest.TestCase):
         self.assertTrue(os.path.isfile("tests/tmp/audio/a.m4a"))
         self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.m4a"))
         self.assertTrue(os.path.isfile("tests/tmp/a.m4a"))
+
+    def testGstArgs(self):
+        
 
 
 class GUI(unittest.TestCase):

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -18,6 +18,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gst, Gio, Gtk, GLib
 Gst.init([None] + [a for a in sys.argv[1:] if '-gst' in a])
 
+import inspect
 from soundconverter.settings import settings
 from soundconverter.namegenerator import TargetNameGenerator
 from soundconverter.soundfile import SoundFile
@@ -30,6 +31,16 @@ from importlib.machinery import SourceFileLoader
 
 DEFAULT_SETTINGS = settings.copy()
 
+gio_settings = Gio.Settings('org.soundconverter')
+
+gio_settings_original_mapping = {key: gio_settings.get_value(key) for key in gio_settings.keys()}
+
+gio_settings.set_boolean('delete-original', False)
+
+for key in gio_settings_original_mapping:
+    gio_settings.set_value(key, gio_settings_original_mapping[key])
+
+print(gio_settings.get_value('delete-original'))
 
 # tests will control gtk main iterations
 Gtk.main = gtk_iteration
@@ -41,6 +52,7 @@ def launch(argv=[]):
     
     Make sure to run the `make` command first in your terminal.
     """
+    exit()
     testargs = sys.argv.copy()[:2]
     testargs += argv
     with patch.object(sys, 'argv', testargs):
@@ -173,9 +185,6 @@ class Batch(unittest.TestCase):
         self.assertTrue(os.path.isfile("tests/tmp/audio/a.m4a"))
         self.assertTrue(os.path.isfile("tests/tmp/audio/b/c.m4a"))
         self.assertTrue(os.path.isfile("tests/tmp/a.m4a"))
-
-    def testGstArgs(self):
-        
 
 
 class GUI(unittest.TestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""utils used by tests"""
+
+
+from soundconverter.settings import settings
+
+
+DEFAULT_SETTINGS = settings.copy()
+
+
+def reset_settings():
+    """Reset the global settings to their initial state."""
+    global settings
+    # convert to list otherwise del won't work
+    for key in list(settings.keys()):
+        if key in DEFAULT_SETTINGS:
+            settings[key] = DEFAULT_SETTINGS[key]
+        else:
+            del settings[key]
+    # batch tests assume that recursive is off by default:
+    assert (("recursive" not in settings) or (not settings["recursive"]))


### PR DESCRIPTION
- uses the logging module now, since that is what many python modules use - makes the code possibly more familiar - and it allows to log to files and such if that is required at some point.
- correctly forwards `--gst-` arguments. For example `soundconverter --gst-debug-level=3`. See https://gstreamer.freedesktop.org/documentation/application-development/appendix/checklist-element.html?gi-language=python#debugging and `gst-launch-1.0 --help-gst`
- does not modify the users setting during `make test` using a memory backend (https://github.com/kassoulet/soundconverter/pull/30#issuecomment-485700568). The way how the code gets the Gio.Settings object had to be changed a bit for this.
- moved from `'%s' % 'string'` to the newer `'{}'.format('string')` formatting almost everywhere
- clarified differences between argv and gio settings
- put audio-format related code from settings into separate file
- splitted test file into multiple files
- fixed changing the number of jobs required a restart
- fixed deprecation warnings for Gtk.Dialog
- rearranged readme a bit

example showing gstreamers debug messages and our new colored debug logs. The lines saying "WARN" in yellow are gstreamers debug messages.

![Screenshot_2020-06-20_20-05-57](https://user-images.githubusercontent.com/28510156/85210886-1504b700-b344-11ea-97ad-a69d122e1d53.png)
![Screenshot_2020-06-21_10-35-45](https://user-images.githubusercontent.com/28510156/85220508-3ac5a680-b3ac-11ea-9d2c-a3f1393a5b4b.png)

gstreamer really logs a lot of things with increasing verbosity (up to 9). I removed the debug logs for the message types at some point because they were actually a bit too much, so the screenshot is a bit outdated.