### PR TITLE
forgot colons in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ As well as the debian repositories::
 Help
 ----
 
-For command line args, see
+For command line args, see::
 
     sounconverter --help
     gst-launch-1.0 --help-gst


### PR DESCRIPTION
I forgot the "::" to indicate code in the last readme change.