### PR TITLE
ubuntu installation & glib schema compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ performance, the command line tools are always going to be preferable.
     <img src="data/screenshot.png" alt="SoundConverter Screenshot"/>
 </p>
 
-## Building and installation
+## Building and Installation
 
-To build and run from the latest source, use
+Ubuntu and Arch packages exist in the official repositories.
+
+Installing from source requires distutils-extra
 
 ```bash
 git clone https://github.com/kassoulet/soundconverter.git
@@ -24,8 +26,6 @@ git checkout py3k
 sudo python3 setup.py install
 soundconverter
 ```
-
-Ubuntu and Arch packages exist in the official repositories.
 
 ## Help
 

--- a/bin/soundconverter
+++ b/bin/soundconverter
@@ -42,11 +42,11 @@ SOURCE_PATH = pkg_resources.require('soundconverter')[0].location
 # depending on where this file is installed to, make sure to use the proper prefix path for data
 # https://docs.python.org/3/distutils/setupscript.html?highlight=package_data#installing-additional-files
 if SOURCE_PATH.startswith(site.USER_BASE):
-    # /home
     DATA_PATH = os.path.join(site.USER_BASE, 'share/soundconverter')
-elif SOURCE_PATH.startswith(sys.prefix):
-    # /usr
-    DATA_PATH = os.path.join(sys.prefix, 'share/soundconverter')
+elif SOURCE_PATH.startswith('/usr/local/'):
+    DATA_PATH = '/usr/local/share/soundconverter'
+elif SOURCE_PATH.startswith('/usr/'):
+    DATA_PATH = '/usr/share/soundconverter'
 else:
     # installed with -e, running from the cloned git source
     DATA_PATH = os.path.join(SOURCE_PATH, 'data')

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,52 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# SoundConverter - GNOME application for converting between audio formats.
+# Copyright 2004 Lars Wirzenius
+# Copyright 2005-2017 Gautier Portet
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA
+
+import os
 import DistUtilsExtra.auto
 
-# this will automatically, assuming that the prefix is /usr
-# - compile and install po files to /usr/share/locale*.mo,
-# - install .desktop files to /usr/share/applications
-# - install all the py files to /usr/lib/python3.8/site-packages/soundconverter
-# - copy bin to /usr/bin
-# - copy the rest to /usr/share/soundconverter, like the .glade file
+# This will automatically, assuming that the prefix is /usr
+# - Compile and install po files to /usr/share/locale*.mo,
+# - Install .desktop files to /usr/share/applications
+# - Install all the py files to /usr/lib/python3.8/site-packages/soundconverter
+# - Copy bin to /usr/bin
+# - Copy the rest to /usr/share/soundconverter, like the .glade file
+# Thanks to DistUtilsExtra (https://salsa.debian.org/python-team/modules/python-distutils-extra/-/tree/master/doc)
+
+class PostInstallation(DistUtilsExtra.auto.install_auto):
+    def run(self):
+        if not self.prefix:
+            self.prefix = ''
+        
+        print('self.prefix', self.prefix)
+
+        DistUtilsExtra.auto.install_auto.run(self)
+
+        # after DistUtilsExtra automatically copied  data/org.soundconverter.gschema.xml
+        # to /usr/share/glib-2.0/schemas/ it doesn't seem to compile them.
+        glib_schema_path = os.path.join(self.prefix, 'share/glib-2.0/schemas/')
+
+        print('glib_schema_path', glib_schema_path)
+
+        os.system('glib-compile-schemas {}'.format(glib_schema_path))
+
 DistUtilsExtra.auto.setup(
     name='soundconverter',
     version='3.0.2',
@@ -17,6 +58,9 @@ DistUtilsExtra.auto.setup(
     data_files=[
         ('share/metainfo/', ['data/soundconverter.appdata.xml']),
         ('share/pixmaps/', ['data/soundconverter.png']),
-        ('share/icons/hicolor/scalable/apps', ['data/soundconverter.svg']),
+        ('share/icons/hicolor/scalable/apps/', ['data/soundconverter.svg'])
     ],
+    cmdclass={
+        'install': PostInstallation
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,13 @@ class PostInstallation(DistUtilsExtra.auto.install_auto):
             self.prefix = ''
         
         print('self.prefix', self.prefix)
+        print('self.install_data', self.install_data)
 
         DistUtilsExtra.auto.install_auto.run(self)
 
         # after DistUtilsExtra automatically copied  data/org.soundconverter.gschema.xml
         # to /usr/share/glib-2.0/schemas/ it doesn't seem to compile them.
-        glib_schema_path = os.path.join(self.prefix, 'share/glib-2.0/schemas/')
+        glib_schema_path = os.path.join(self.install_data, 'share/glib-2.0/schemas/')
 
         print('glib_schema_path', glib_schema_path)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import DistUtilsExtra.auto
 # - Copy the rest to /usr/share/soundconverter, like the .glade file
 # Thanks to DistUtilsExtra (https://salsa.debian.org/python-team/modules/python-distutils-extra/-/tree/master/doc)
 
-class PostInstallation(DistUtilsExtra.auto.install_auto):
+class Install(DistUtilsExtra.auto.install_auto):
     def run(self):
         DistUtilsExtra.auto.install_auto.run(self)
         # after DistUtilsExtra automatically copied data/org.soundconverter.gschema.xml
@@ -54,6 +54,6 @@ DistUtilsExtra.auto.setup(
         ('share/icons/hicolor/scalable/apps/', ['data/soundconverter.svg'])
     ],
     cmdclass={
-        'install': PostInstallation
+        'install': Install
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -32,21 +32,13 @@ import DistUtilsExtra.auto
 
 class PostInstallation(DistUtilsExtra.auto.install_auto):
     def run(self):
-        if not self.prefix:
-            self.prefix = ''
-        
-        print('self.prefix', self.prefix)
-        print('self.install_data', self.install_data)
-
         DistUtilsExtra.auto.install_auto.run(self)
-
-        # after DistUtilsExtra automatically copied  data/org.soundconverter.gschema.xml
+        # after DistUtilsExtra automatically copied data/org.soundconverter.gschema.xml
         # to /usr/share/glib-2.0/schemas/ it doesn't seem to compile them.
         glib_schema_path = os.path.join(self.install_data, 'share/glib-2.0/schemas/')
-
-        print('glib_schema_path', glib_schema_path)
-
-        os.system('glib-compile-schemas {}'.format(glib_schema_path))
+        cmd = 'glib-compile-schemas {}'.format(glib_schema_path)
+        print('running {}'.format(cmd))
+        os.system(cmd)
 
 DistUtilsExtra.auto.setup(
     name='soundconverter',


### PR DESCRIPTION
- DistUtilsExtra will install stuff to `/usr/local` automatically in ubuntu, which wasn't properly detected yet.
- DistUtilsExtra copied the schema files, but it didn't run the `glib-compile-schemas` command automatically