### PR TITLE
GTK progress optimizations and properly closing gst.pipeline

### DIFF
--- a/soundconverter/gstreamer/converter.py
+++ b/soundconverter/gstreamer/converter.py
@@ -238,15 +238,13 @@ class Converter(Task):
         """Fraction of how much of the task is completed."""
         duration = self.sound_file.duration
 
-        # don't waste time querying gstreamer if possible
-        if self.done:
-            return 1, duration
-        if not self.pipeline:
+        if self.pipeline is None or duration is None:
             return 0, duration
 
+        if self.done:
+            return 1, duration
+
         position = self._query_position()
-        if duration is None:
-            return 0
         progress = position / duration
         progress = min(max(progress, 0.0), 1.0)
         return progress, duration

--- a/soundconverter/gstreamer/converter.py
+++ b/soundconverter/gstreamer/converter.py
@@ -237,15 +237,19 @@ class Converter(Task):
     def get_progress(self):
         """Fraction of how much of the task is completed."""
         duration = self.sound_file.duration
-        if not self.done:
-            position = self._query_position()
-            if duration is None:
-                return 0
-            progress = position / duration
-            progress = min(max(progress, 0.0), 1.0)
-            return progress, duration
 
-        return 1, duration
+        # don't waste time querying gstreamer if possible
+        if self.done:
+            return 1, duration
+        if not self.pipeline:
+            return 0, duration
+
+        position = self._query_position()
+        if duration is None:
+            return 0
+        progress = position / duration
+        progress = min(max(progress, 0.0), 1.0)
+        return progress, duration
 
     def cancel(self):
         """Cancel execution of the task."""

--- a/soundconverter/gstreamer/converter.py
+++ b/soundconverter/gstreamer/converter.py
@@ -238,11 +238,11 @@ class Converter(Task):
         """Fraction of how much of the task is completed."""
         duration = self.sound_file.duration
 
-        if self.pipeline is None or duration is None:
-            return 0, duration
-
         if self.done:
             return 1, duration
+
+        if self.pipeline is None or duration is None:
+            return 0, duration
 
         position = self._query_position()
         progress = position / duration
@@ -267,6 +267,14 @@ class Converter(Task):
             return
         self.pipeline.set_state(Gst.State.PLAYING)
 
+    def _cleanup(self):
+        """Delete the pipeline."""
+        bus = self.pipeline.get_bus()
+        bus.disconnect(self.watch_id)
+        bus.remove_signal_watch()
+        self.pipeline.set_state(Gst.State.NULL)
+        self.pipeline = None
+
     def _stop_pipeline(self):
         # remove partial file
         if self.temporary_filename is not None:
@@ -281,11 +289,7 @@ class Converter(Task):
         if not self.pipeline:
             logger.debug('pipeline already stopped!')
             return
-        self.pipeline.set_state(Gst.State.NULL)
-        bus = self.pipeline.get_bus()
-        bus.disconnect(self.watch_id)
-        bus.remove_signal_watch()
-        self.pipeline = None
+        self._cleanup()
 
     def _convert(self):
         """Run the gst pipeline that converts files.
@@ -325,13 +329,6 @@ class Converter(Task):
         if newname is None:
             raise AssertionError('the conversion was not started')
 
-        if not vfs_exists(self.temporary_filename):
-            self.error = 'Expected {} to exist after conversion.'.format(
-                self.temporary_filename
-            )
-            self.callback()
-            return
-
         if self.error:
             logger.debug('error in task, skipping rename: {}'.format(
                 self.temporary_filename
@@ -340,6 +337,13 @@ class Converter(Task):
             logger.info('could not convert {}: {}'.format(
                 beautify_uri(input_uri), self.error
             ))
+            self.callback()
+            return
+
+        if not vfs_exists(self.temporary_filename):
+            self.error = 'Expected {} to exist after conversion.'.format(
+                self.temporary_filename
+            )
             self.callback()
             return
 
@@ -410,6 +414,7 @@ class Converter(Task):
         self.output_uri = newname
         self.done = True
         self.callback()
+        self._cleanup()
 
     def run(self):
         """Call this in order to run the whole Converter task."""

--- a/soundconverter/interface/ui.py
+++ b/soundconverter/interface/ui.py
@@ -114,8 +114,8 @@ class ErrorDialog:
         self.secondary = builder.get_object('secondary_error_label')
 
     def show_error(self, primary, secondary):
-        self.primary.set_markup(primary)
-        self.secondary.set_markup(secondary)
+        self.primary.set_markup(str(primary))
+        self.secondary.set_markup(str(secondary))
         try:
             sys.stderr.write(_('\nError: %s\n%s\n') % (primary, secondary))
         except Exception:

--- a/soundconverter/interface/ui.py
+++ b/soundconverter/interface/ui.py
@@ -445,7 +445,9 @@ class FileList:
     def set_row_progress(self, number, progress):
         """Update the progress bar of a single row/file."""
         self.progress_column.set_visible(True)
-        if self.model[number][2] == 1.0:
+        if abs(self.model[number][2] - progress * 100) < 1:
+            # only do the expensive gtk update when the delta progress
+            # is larger than 1%
             return
 
         self.model[number][2] = progress * 100.0

--- a/soundconverter/interface/ui.py
+++ b/soundconverter/interface/ui.py
@@ -445,9 +445,7 @@ class FileList:
     def set_row_progress(self, number, progress):
         """Update the progress bar of a single row/file."""
         self.progress_column.set_visible(True)
-        if abs(self.model[number][2] - progress * 100) < 1:
-            # only do the expensive gtk update when the delta progress
-            # is larger than 1%
+        if self.model[number][2] == progress * 100:
             return
 
         self.model[number][2] = progress * 100.0


### PR DESCRIPTION
The UI froze when converting too many files, because it updated each ones progress even though it remained the same for most files (0.0 or 1.0 when done). This was quite expensive. The change in `converter.py` is only for cosmetic reasons mostly as it didn't seem to have a large impact. Furthermore, pipelines are properly cleaned after conversion because at some point soundconverter crashed because of too many open files.

I obviously should have done a stresstest earlier.

Also added an integration test for cancelling pipelines.