### PR TITLE
Find DATA_PATH from flatpak

### DIFF
--- a/bin/soundconverter
+++ b/bin/soundconverter
@@ -44,6 +44,9 @@ elif SOURCE_PATH.startswith('/usr/local/'):
     DATA_PATH = '/usr/local/share/soundconverter'
 elif SOURCE_PATH.startswith('/usr/'):
     DATA_PATH = '/usr/share/soundconverter'
+elif SOURCE_PATH.startswith('/app/'):
+    # flatpak support
+    DATA_PATH = '/app/share/soundconverter'
 else:
     # installed with -e, running from the cloned git source
     DATA_PATH = os.path.join(SOURCE_PATH, 'data')


### PR DESCRIPTION
Since flatpaks require an application to store all its related data in the `/app/` path, the current logic to determine the `DATA_PATH` doesn't work for flatpaks. This PR fixes this.

Background: I am currently working on a [flatpak](https://flatpak.org) bundle of SoundConverter to be made available via [flathub](https://flathub.org). If you are interested (and have `flatpak` and `flatpak-builder` installed), you can download the [PR for my org.soundconverter.SoundConverter manifest](https://github.com/flathub/flathub/pull/1946) and then build and install it locally:

    flatpak-builder --user --install /path/to/your/builddir /path/to/org.soundconverter.SoundConverter.yml

And then start it via:

    flatpak run --user org.soundconverter.SoundConverter