### PR TITLE
Remove unused <data> list in soundconverter.glade

### DIFF
--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -592,14 +592,6 @@ Gautier Portet</property>
       <!-- column-name item -->
       <column type="gchararray"/>
     </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">track_number - track_title</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">track_title</col>
-      </row>
-    </data>
   </object>
   <object class="GtkListStore" id="liststore_resample">
     <columns>

--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -599,9 +599,6 @@ Gautier Portet</property>
       <row>
         <col id="0" translatable="yes">track_title</col>
       </row>
-      <row>
-        <col id="0" translatable="yes"/>
-      </row>
     </data>
   </object>
   <object class="GtkListStore" id="liststore_resample">


### PR DESCRIPTION
This fixes the following runtime warning(s):

```
/app/lib/python3.8/site-packages/soundconverter/interface/ui.py:1443: Warning: g_value_type_transformable: assertion 'src_type' failed
  builder.add_from_file(gladefile)

(soundconverter:2): Gtk-WARNING **: 18:11:39.109: ../gtk/gtkliststore.c:834: Unable to convert from (null) to gchararray
```