### PR TITLE
Support deleting original files when converting from CLI

### DIFF
--- a/bin/soundconverter
+++ b/bin/soundconverter
@@ -144,6 +144,10 @@ def parse_command_line():
         '-j', '--jobs', action='store', type='int', dest='forced-jobs',
         metavar='NUM', help=_('Force number of concurrent conversions.')
     )
+    parser.add_option(
+        '-D', '--delete-original', action='store_true', dest='delete-original',
+        help=_('Deletes the original file when conversion is done.')
+    )
 
     # batch mode settings
     batch_option_group = OptionGroup(

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,6 @@ DistUtilsExtra.auto.setup(
     ],
     cmdclass={
         'install': Install
-    }
+    },
+    scripts=["bin/soundconverter"]
 )

--- a/soundconverter/interface/batch.py
+++ b/soundconverter/interface/batch.py
@@ -64,7 +64,7 @@ def use_memory_gsettings(options):
     gio_settings = Gio.Settings.new_with_backend('org.soundconverter', backend)
     set_gio_settings(gio_settings)
 
-    gio_settings.set_boolean('delete-original', False)
+    gio_settings.set_boolean('delete-original', options.get('delete-original', False))
 
     if options.get('main') == 'batch':
         # the number of jobs is only applied, when limit-jobs is true

--- a/tests/testcases/batch.py
+++ b/tests/testcases/batch.py
@@ -336,6 +336,19 @@ class BatchUtils(unittest.TestCase):
         gio_settings = get_gio_settings()
         self.assertFalse(gio_settings.get_boolean('delete-original'))
 
+    def test_set_delete_original_true(self):
+        gio_settings = get_gio_settings()
+        gio_settings.set_boolean('delete-original', False)
+        use_memory_gsettings({
+            'output-path': '.',
+            'main': 'batch',
+            'format': 'ogg',
+            'quality': '0.5',
+            'delete-original': True
+        })
+        gio_settings = get_gio_settings()
+        self.assertTrue(gio_settings.get_boolean('delete-original'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testcases/integration.py
+++ b/tests/testcases/integration.py
@@ -432,6 +432,26 @@ class BatchIntegration(unittest.TestCase):
         gio_settings = get_gio_settings()
         self.assertFalse(gio_settings.get_boolean('delete-original'))
 
+    def test_set_delete_original_true(self):
+        gio_settings = get_gio_settings()
+        gio_settings.set_boolean('delete-original', False)
+        gio_settings = get_gio_settings()
+        self.assertFalse(gio_settings.get_boolean('delete-original'))
+
+        os.system('cp "tests/test data/audio/a.wav" "tests/tmp/a.wav"')
+        self.assertTrue(os.path.isfile('tests/tmp/a.wav'))
+
+        launch([
+            '-b', 'tests/tmp/a.wav',
+            '-o', 'tests/tmp',
+            '-f', 'm4a',
+            '-D',
+        ])
+
+        gio_settings = get_gio_settings()
+        self.assertTrue(gio_settings.get_boolean('delete-original'))
+        self.assertFalse(os.path.isfile('tests/tmp/a.wav'))
+
     def test_conversion_no_tags(self):
         launch([
             '-b', 'tests/test data/no tags',


### PR DESCRIPTION
This add options `-D` and `--delete-original` to support deleting original files when conversion is done. This PR does not includes translations in english and french because I don't know how to deal with `.po` files. Don't hesitate to tell me if you want this to be embedded in this PR.

Also, there's no tests as this was quite trivial. Tell me if you need them.