### PR TITLE
Add <launchable> tag to appdata

### DIFF
--- a/data/soundconverter.appdata.xml
+++ b/data/soundconverter.appdata.xml
@@ -28,6 +28,7 @@ SoundConverter is a simple to use, and very fast audio converter. It can convert
   <url type="translate">https://translations.launchpad.net/soundconverter</url>
 
   <content_rating type="oars-1.1" />
+  <launchable type="desktop-id">soundconverter.desktop</launchable>
 
   <releases>
     <release date="2023-07-17" version="4.0.4"/>


### PR DESCRIPTION
Flathub requires this to be present in the appstream metadata. Otherwise builds are rejected from flathub.

See: https://buildbot.flathub.org/#/builders/6/builds/108488