### PR TITLE
Partially switch from pkg_resources to importlib.metadata because of deprecation. 

### DIFF
--- a/bin/soundconverter
+++ b/bin/soundconverter
@@ -32,11 +32,14 @@ import gettext
 
 _ = gettext.gettext
 import pkg_resources
+from importlib.metadata import metadata
 
 # read values from setup.py
-VERSION = pkg_resources.require('soundconverter')[0].version
-NAME = pkg_resources.require('soundconverter')[0].project_name
+soundconverter_metadata = metadata('soundconverter')  
+NAME = soundconverter_metadata['Name']
+VERSION = version('soundconverter')
 SOURCE_PATH = pkg_resources.require('soundconverter')[0].location
+
 
 # depending on where this file is installed to, make sure to use the proper
 # prefix path for data

--- a/bin/soundconverter
+++ b/bin/soundconverter
@@ -37,7 +37,7 @@ from importlib.metadata import metadata
 # read values from setup.py
 soundconverter_metadata = metadata('soundconverter')  
 NAME = soundconverter_metadata['Name']
-VERSION = version('soundconverter')
+VERSION = soundconverter_metadata['version']
 SOURCE_PATH = pkg_resources.require('soundconverter')[0].location
 
 


### PR DESCRIPTION
partially add in importlib.metadata, get rid of some dependency on pkg_resources where it's simpler to.
When running sound converter from the commandline I always get a warning saying that pkg_resources is deprecated. I found some documentation saying that importlib.metadata is a good replacement for pkg_resources so I thought it would be good to use. Most of the changes are simple but I didn't find a simple way to implement package location metadata so that was left unchanged and pkg_resources still gets imported. 
https://setuptools.pypa.io/en/latest/pkg_resources.html 
