### PR TITLE
Exclude files without any audio streams from processing.

### DIFF
--- a/soundconverter/gstreamer/discoverer.py
+++ b/soundconverter/gstreamer/discoverer.py
@@ -119,6 +119,11 @@ class DiscovererThread(Thread):
             discoverer = GstPbutils.Discoverer()
             info = discoverer.discover_uri(sound_file.uri)
 
+            audio_streams = info.get_audio_streams()
+            if not audio_streams:
+                # no audio streams available, not an audio file
+                return
+
             # whatever anybody might ever need from it, here it is:
             sound_file.info = info
 
@@ -127,7 +132,7 @@ class DiscovererThread(Thread):
             if taglist:
                 taglist.foreach(lambda *args: self._add_tag(*args, sound_file))
 
-            for audio_stream in info.get_audio_streams():
+            for audio_stream in audio_streams:
                 # Read tags for each audio stream
                 taglist = audio_stream.get_tags()
                 if taglist:


### PR DESCRIPTION
Soundconverter currently filters out files that have a duration of zero from processing, as a way of filtering out files that aren't actually audio files. This approach fails to filter out animated GIFs, which have a non-zero duration. Running soundconverter in batch recursive mode over a directory that contains an animated GIF will therefore cause it to attempt to convert the animated GIF. At least on my machine with the settings I was trying, this causes soundconverter to run forever, probably because the underlying gstreamer pipeline gets blocked, throws an error, etc. This PR causes soundconverter to filter out any files that don't have any audio streams, which will cause animated GIFs to be excluded.