### PR TITLE
Make the Preferences dialog scrollable

### DIFF
--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -605,6 +605,7 @@ Gautier Portet</property>
   <object class="GtkDialog" id="prefsdialog">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
+    <property name="default-height">750</property>
     <property name="destroy-with-parent">True</property>
     <property name="icon-name">soundconverter</property>
     <property name="type-hint">dialog</property>
@@ -643,6 +644,12 @@ Gautier Portet</property>
           </packing>
         </child>
         <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <property name="min-content-height">250</property>
+            <child>
           <object class="GtkBox" id="vbox12">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -1873,6 +1880,8 @@ Gautier Portet</property>
                 <property name="fill">True</property>
                 <property name="position">7</property>
               </packing>
+            </child>
+          </object>
             </child>
           </object>
           <packing>

--- a/data/soundconverter.glade
+++ b/data/soundconverter.glade
@@ -650,1238 +650,1238 @@ Gautier Portet</property>
             <property name="hscrollbar-policy">never</property>
             <property name="min-content-height">250</property>
             <child>
-          <object class="GtkBox" id="vbox12">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="border-width">12</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkFrame" id="frame1">
+              <object class="GtkBox" id="vbox12">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label-xalign">0</property>
-                <property name="shadow-type">none</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
                 <child>
-                  <object class="GtkAlignment" id="alignment2">
+                  <object class="GtkFrame" id="frame1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="top-padding">4</property>
-                    <property name="left-padding">12</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
-                      <object class="GtkTable" id="table2">
+                      <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="n-rows">4</property>
-                        <property name="n-columns">2</property>
-                        <property name="column-spacing">4</property>
-                        <property name="row-spacing">4</property>
+                        <property name="top-padding">4</property>
+                        <property name="left-padding">12</property>
                         <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <object class="GtkComboBox" id="subfolder_pattern">
+                          <object class="GtkTable" id="table2">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="model">liststore10</property>
-                            <signal name="changed" handler="on_subfolder_pattern_changed" swapped="no"/>
-                            <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext10"/>
-                              <attributes>
-                                <attribute name="text">0</attribute>
-                              </attributes>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">2</property>
-                            <property name="bottom-attach">3</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="same_folder_as_input">
-                            <property name="label" translatable="yes">Same folder as the input file</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="xalign">0.5</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="on_same_folder_as_input_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="choose_folder">
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <signal name="clicked" handler="on_choose_folder_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkAlignment" id="alignment5">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="xscale">0</property>
-                                <property name="yscale">0</property>
-                                <child>
-                                  <object class="GtkBox" id="hbox15">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="spacing">2</property>
-                                    <child>
-                                      <object class="GtkImage" id="image4">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="stock">gtk-open</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="label19">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="margin-start">5</property>
-                                        <property name="label" translatable="yes">Choose…</property>
-                                        <property name="use-underline">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">1</property>
-                            <property name="bottom-attach">2</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="into_selected_folder">
-                            <property name="label" translatable="yes">Into a specified folder</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="width-request">320</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="xalign">0.5</property>
-                            <property name="draw-indicator">True</property>
-                            <property name="group">same_folder_as_input</property>
-                            <signal name="toggled" handler="on_into_selected_folder_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="top-attach">1</property>
-                            <property name="bottom-attach">2</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="create_subfolders">
-                            <property name="label" translatable="yes">Create subfolders: </property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="xalign">0.5</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="on_create_subfolders_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="top-attach">2</property>
-                            <property name="bottom-attach">3</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="delete_original">
-                            <property name="label" translatable="yes">Delete original file</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="xalign">0.5</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="on_delete_original_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="top-attach">3</property>
-                            <property name="bottom-attach">4</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label16">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-bottom">6</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Where to place results?&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="frame2">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label-xalign">0</property>
-                <property name="shadow-type">none</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment3">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="top-padding">4</property>
-                    <property name="left-padding">12</property>
-                    <child>
-                      <object class="GtkBox" id="vbox13">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">4</property>
-                        <child>
-                          <object class="GtkComboBox" id="basename_pattern">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="model">liststore9</property>
-                            <signal name="changed" handler="on_basename_pattern_changed" swapped="no"/>
-                            <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext9"/>
-                              <attributes>
-                                <attribute name="text">0</attribute>
-                              </attributes>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="custom_filename_box">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">4</property>
-                            <child>
-                              <object class="GtkLabel" id="label34">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Filename pattern: </property>
-                                <property name="xalign">0</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="custom_filename">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="invisible-char">●</property>
-                                <property name="primary-icon-activatable">False</property>
-                                <property name="secondary-icon-activatable">False</property>
-                                <signal name="changed" handler="on_custom_filename_changed" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="replace_messy_chars">
-                            <property name="label" translatable="yes">Replace all messy characters</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">Remove all characters except letters, digits and ./_-</property>
-                            <property name="use-underline">True</property>
-                            <property name="xalign">0.5</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="on_replace_messy_chars_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="hbox18">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">4</property>
-                            <child>
-                              <object class="GtkLabel" id="label26">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">&lt;i&gt;Example filename:&lt;/i&gt;</property>
-                                <property name="use-markup">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="example_filename">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label">label27</property>
-                                <property name="use-markup">True</property>
-                                <property name="wrap">True</property>
-                                <property name="ellipsize">start</property>
-                                <property name="single-line-mode">True</property>
-                                <property name="xalign">0</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="n-rows">4</property>
+                            <property name="n-columns">2</property>
+                            <property name="column-spacing">4</property>
+                            <property name="row-spacing">4</property>
                             <child>
                               <placeholder/>
                             </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label17">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-top">24</property>
-                    <property name="margin-bottom">6</property>
-                    <property name="label" translatable="yes">&lt;b&gt;How to name files?&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="frame3">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label-xalign">0</property>
-                <property name="shadow-type">none</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment4">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="top-padding">4</property>
-                    <property name="left-padding">12</property>
-                    <child>
-                      <object class="GtkBox" id="vbox14">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkBox" id="hbox19">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">6</property>
                             <child>
-                              <object class="GtkLabel" id="label32">
-                                <property name="width-request">100</property>
+                              <object class="GtkComboBox" id="subfolder_pattern">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Format: </property>
-                                <property name="xalign">0</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="output_mime_type">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="model">liststore8</property>
-                                <signal name="changed" handler="on_output_mime_type_changed" swapped="no"/>
+                                <property name="model">liststore10</property>
+                                <signal name="changed" handler="on_subfolder_pattern_changed" swapped="no"/>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext8"/>
+                                  <object class="GtkCellRendererText" id="cellrenderertext10"/>
                                   <attributes>
                                     <attribute name="text">0</attribute>
                                   </attributes>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <object class="GtkNotebook" id="quality_tabs">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="tab-pos">bottom</property>
-                            <property name="show-border">False</property>
                             <child>
-                              <object class="GtkTable" id="table3">
+                              <object class="GtkRadioButton" id="same_folder_as_input">
+                                <property name="label" translatable="yes">Same folder as the input file</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">3</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">6</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="vorbis_quality">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore7</property>
-                                    <signal name="changed" handler="on_vorbis_quality_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext7"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label29">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Quality:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="vorbis_oga_extension">
-                                    <property name="label" translatable="yes">Use .oga extension</property>
-                                    <property name="use-action-appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="xalign">0</property>
-                                    <property name="draw-indicator">True</property>
-                                    <signal name="toggled" handler="on_vorbis_oga_extension_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label22">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Ogg</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_same_folder_as_input_toggled" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="tab-fill">False</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkTable" id="table4">
+                              <object class="GtkButton" id="choose_folder">
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">4</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">4</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <signal name="clicked" handler="on_choose_folder_clicked" swapped="no"/>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="mp3_mode">
+                                  <object class="GtkAlignment" id="alignment5">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="model">liststore6</property>
-                                    <signal name="changed" handler="on_mp3_mode_changed" swapped="no"/>
+                                    <property name="xscale">0</property>
+                                    <property name="yscale">0</property>
                                     <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext6"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="mp3_quality">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore5</property>
-                                    <signal name="changed" handler="on_mp3_quality_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext5"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label30">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Bitrate mode:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label31">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Quality:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="hbox1">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spinbutton1">
-                                        <property name="can-focus">True</property>
-                                        <property name="invisible-char">●</property>
-                                        <property name="primary-icon-activatable">False</property>
-                                        <property name="secondary-icon-activatable">False</property>
+                                      <object class="GtkBox" id="hbox15">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">2</property>
+                                        <child>
+                                          <object class="GtkImage" id="image4">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="stock">gtk-open</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label19">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-start">5</property>
+                                            <property name="label" translatable="yes">Choose…</property>
+                                            <property name="use-underline">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="top-attach">3</property>
-                                    <property name="bottom-attach">4</property>
-                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label23">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">MP3</property>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                                <property name="tab-fill">False</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkTable" id="table1">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">2</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">4</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label1">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Compression:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="flac_compression">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore4</property>
-                                    <signal name="changed" handler="on_flac_compression_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext4"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label24">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">FLAC</property>
-                              </object>
-                              <packing>
-                                <property name="position">2</property>
-                                <property name="tab-fill">False</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkTable" id="table6">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">2</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">4</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label2">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Sample width:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="wav_sample_width">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore3</property>
-                                    <signal name="changed" handler="on_wav_sample_width_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext3"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label25">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">WAV</property>
-                              </object>
-                              <packing>
-                                <property name="position">3</property>
-                                <property name="tab-fill">False</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkTable" id="table5">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">2</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">6</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label38">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Quality:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="aac_quality">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore2</property>
-                                    <signal name="changed" handler="on_aac_quality_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext2"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label111">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">AAC</property>
-                              </object>
-                              <packing>
-                                <property name="position">4</property>
-                                <property name="tab-fill">False</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkTable" id="table5b">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="n-rows">2</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">6</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label38b">
-                                    <property name="width-request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Quality:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="opus_quality">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="model">liststore2</property>
-                                    <signal name="changed" handler="on_opus_quality_changed" swapped="no"/>
-                                    <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext2b"/>
-                                      <attributes>
-                                        <attribute name="text">0</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label111b">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Opus</property>
-                              </object>
-                              <packing>
-                                <property name="position">5</property>
-                                <property name="tab-fill">False</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <placeholder/>
                             </child>
                             <child>
-                              <object class="GtkTable" id="table5c">
+                              <object class="GtkRadioButton" id="into_selected_folder">
+                                <property name="label" translatable="yes">Into a specified folder</property>
+                                <property name="use-action-appearance">False</property>
+                                <property name="width-request">320</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw-indicator">True</property>
+                                <property name="group">same_folder_as_input</property>
+                                <signal name="toggled" handler="on_into_selected_folder_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                                <property name="y-options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="create_subfolders">
+                                <property name="label" translatable="yes">Create subfolders: </property>
+                                <property name="use-action-appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_create_subfolders_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                                <property name="y-options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="delete_original">
+                                <property name="label" translatable="yes">Delete original file</property>
+                                <property name="use-action-appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_delete_original_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="top-attach">3</property>
+                                <property name="bottom-attach">4</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label16">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Where to place results?&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
+                    <child>
+                      <object class="GtkAlignment" id="alignment3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="top-padding">4</property>
+                        <property name="left-padding">12</property>
+                        <child>
+                          <object class="GtkBox" id="vbox13">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkComboBox" id="basename_pattern">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="n-rows">2</property>
-                                <property name="n-columns">2</property>
-                                <property name="column-spacing">6</property>
-                                <property name="row-spacing">6</property>
+                                <property name="model">liststore9</property>
+                                <signal name="changed" handler="on_basename_pattern_changed" swapped="no"/>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkCellRendererText" id="cellrenderertext9"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
                                 </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="custom_filename_box">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">4</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label38c">
-                                    <property name="width-request">100</property>
+                                  <object class="GtkLabel" id="label34">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Quality:</property>
+                                    <property name="label" translatable="yes">Filename pattern: </property>
                                     <property name="xalign">0</property>
                                   </object>
                                   <packing>
-                                    <property name="x-options">GTK_FILL</property>
-                                    <property name="y-options"/>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkComboBox" id="wma_quality">
+                                  <object class="GtkEntry" id="custom_filename">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="invisible-char">●</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
+                                    <signal name="changed" handler="on_custom_filename_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="replace_messy_chars">
+                                <property name="label" translatable="yes">Replace all messy characters</property>
+                                <property name="use-action-appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Remove all characters except letters, digits and ./_-</property>
+                                <property name="use-underline">True</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_replace_messy_chars_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="hbox18">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">4</property>
+                                <child>
+                                  <object class="GtkLabel" id="label26">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="model">liststore2</property>
-                                    <signal name="changed" handler="on_wma_quality_changed" swapped="no"/>
+                                    <property name="label" translatable="yes">&lt;i&gt;Example filename:&lt;/i&gt;</property>
+                                    <property name="use-markup">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="example_filename">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label">label27</property>
+                                    <property name="use-markup">True</property>
+                                    <property name="wrap">True</property>
+                                    <property name="ellipsize">start</property>
+                                    <property name="single-line-mode">True</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label17">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">24</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="label" translatable="yes">&lt;b&gt;How to name files?&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
+                    <child>
+                      <object class="GtkAlignment" id="alignment4">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="top-padding">4</property>
+                        <property name="left-padding">12</property>
+                        <child>
+                          <object class="GtkBox" id="vbox14">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkBox" id="hbox19">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel" id="label32">
+                                    <property name="width-request">100</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Format: </property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="output_mime_type">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="model">liststore8</property>
+                                    <signal name="changed" handler="on_output_mime_type_changed" swapped="no"/>
                                     <child>
-                                      <object class="GtkCellRendererText" id="cellrenderertext2c"/>
+                                      <object class="GtkCellRendererText" id="cellrenderertext8"/>
                                       <attributes>
                                         <attribute name="text">0</attribute>
                                       </attributes>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="y-options">GTK_FILL</property>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="position">6</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
-                            <child type="tab">
-                              <object class="GtkLabel" id="label111c">
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <object class="GtkNotebook" id="quality_tabs">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">WMA</property>
+                                <property name="can-focus">True</property>
+                                <property name="tab-pos">bottom</property>
+                                <property name="show-border">False</property>
+                                <child>
+                                  <object class="GtkTable" id="table3">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">3</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">6</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="vorbis_quality">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore7</property>
+                                        <signal name="changed" handler="on_vorbis_quality_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext7"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label29">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Quality:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="vorbis_oga_extension">
+                                        <property name="label" translatable="yes">Use .oga extension</property>
+                                        <property name="use-action-appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw-indicator">True</property>
+                                        <signal name="toggled" handler="on_vorbis_oga_extension_toggled" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label22">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Ogg</property>
+                                  </object>
+                                  <packing>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table4">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">4</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">4</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="mp3_mode">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore6</property>
+                                        <signal name="changed" handler="on_mp3_mode_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext6"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="mp3_quality">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore5</property>
+                                        <signal name="changed" handler="on_mp3_quality_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext5"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label30">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Bitrate mode:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label31">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Quality:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hbox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbutton1">
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label23">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">MP3</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">1</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table1">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">4</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label1">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Compression:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="flac_compression">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore4</property>
+                                        <signal name="changed" handler="on_flac_compression_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext4"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label24">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">FLAC</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">2</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table6">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">4</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label2">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Sample width:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="wav_sample_width">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore3</property>
+                                        <signal name="changed" handler="on_wav_sample_width_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext3"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label25">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">WAV</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">3</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table5">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">6</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label38">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Quality:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="aac_quality">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore2</property>
+                                        <signal name="changed" handler="on_aac_quality_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext2"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label111">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">AAC</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">4</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table5b">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">6</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label38b">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Quality:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="opus_quality">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore2</property>
+                                        <signal name="changed" handler="on_opus_quality_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext2b"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">5</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label111b">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Opus</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">5</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <object class="GtkTable" id="table5c">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">6</property>
+                                    <property name="row-spacing">6</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label38c">
+                                        <property name="width-request">100</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Quality:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="wma_quality">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">liststore2</property>
+                                        <signal name="changed" handler="on_wma_quality_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext2c"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="position">6</property>
+                                  </packing>
+                                </child>
+                                <child type="tab">
+                                  <object class="GtkLabel" id="label111c">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">WMA</property>
+                                  </object>
+                                  <packing>
+                                    <property name="position">6</property>
+                                    <property name="tab-fill">False</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
-                                <property name="position">6</property>
-                                <property name="tab-fill">False</property>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="approx_bitrate">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label">~xxx kbps</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="approx_bitrate">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label">~xxx kbps</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">3</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label18">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-top">24</property>
-                    <property name="margin-bottom">6</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Type of result?&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="resample_hbox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="spacing">4</property>
-                <child>
-                  <object class="GtkCheckButton" id="resample_toggle">
-                    <property name="label" translatable="yes">Resample</property>
-                    <property name="use-action-appearance">False</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="receives-default">False</property>
-                    <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
-                    <property name="draw-indicator">True</property>
-                    <signal name="toggled" handler="on_resample_toggle" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="padding">12</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="resample_rate">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="model">liststore_resample</property>
-                    <property name="entry-text-column">0</property>
-                    <signal name="changed" handler="on_resample_rate_changed" swapped="no"/>
+                    <child type="label">
+                      <object class="GtkLabel" id="label18">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">24</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Type of result?&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="resample_Hz_entry">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="label">Hz</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="mono_hbox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="spacing">4</property>
                 <child>
-                  <object class="GtkCheckButton" id="force_mono">
-                    <property name="label" translatable="yes">Force mono output</property>
-                    <property name="use-action-appearance">False</property>
+                  <object class="GtkBox" id="resample_hbox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="receives-default">False</property>
-                    <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
-                    <property name="draw-indicator">True</property>
-                    <signal name="toggled" handler="on_force_mono_toggle" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="padding">12</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="threads_hbox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="spacing">4</property>
-                <child>
-                  <object class="GtkCheckButton" id="jobs">
-                    <property name="label" translatable="yes">Limit number of parallel jobs</property>
-                    <property name="use-action-appearance">False</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
-                    <property name="draw-indicator">True</property>
-                    <signal name="toggled" handler="on_jobs_toggled" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="padding">12</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="jobs_spinbutton">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="invisible-char">•</property>
-                    <property name="primary-icon-activatable">False</property>
-                    <property name="secondary-icon-activatable">False</property>
-                    <property name="adjustment">jobs_adjustment</property>
-                    <property name="climb-rate">1</property>
-                    <signal name="value-changed" handler="on_jobs_spinbutton_value_changed" swapped="no"/>
+                    <property name="spacing">4</property>
+                    <child>
+                      <object class="GtkCheckButton" id="resample_toggle">
+                        <property name="label" translatable="yes">Resample</property>
+                        <property name="use-action-appearance">False</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="xalign">0.5</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="on_resample_toggle" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="padding">12</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="resample_rate">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="model">liststore_resample</property>
+                        <property name="entry-text-column">0</property>
+                        <signal name="changed" handler="on_resample_rate_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="resample_Hz_entry">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label">Hz</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">1</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="lame_absent">
-                <property name="can-focus">False</property>
-                <property name="spacing">4</property>
-                <child>
-                  <object class="GtkHSeparator" id="hseparator1">
+                  <object class="GtkBox" id="mono_hbox">
+                    <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="spacing">4</property>
+                    <child>
+                      <object class="GtkCheckButton" id="force_mono">
+                        <property name="label" translatable="yes">Force mono output</property>
+                        <property name="use-action-appearance">False</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="xalign">0.5</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="on_force_mono_toggle" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="padding">12</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="hbox26">
+                  <object class="GtkBox" id="threads_hbox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="spacing">4</property>
                     <child>
-                      <object class="GtkBox" id="lame_absent_">
+                      <object class="GtkCheckButton" id="jobs">
+                        <property name="label" translatable="yes">Limit number of parallel jobs</property>
+                        <property name="use-action-appearance">False</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="xalign">0.5</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="on_jobs_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="padding">12</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="jobs_spinbutton">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="invisible-char">•</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="secondary-icon-activatable">False</property>
+                        <property name="adjustment">jobs_adjustment</property>
+                        <property name="climb-rate">1</property>
+                        <signal name="value-changed" handler="on_jobs_spinbutton_value_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="lame_absent">
+                    <property name="can-focus">False</property>
+                    <property name="spacing">4</property>
+                    <child>
+                      <object class="GtkHSeparator" id="hseparator1">
+                        <property name="can-focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox26">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="spacing">12</property>
                         <child>
-                          <object class="GtkImage" id="image23">
+                          <object class="GtkBox" id="lame_absent_">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="icon-name">gtk-dialog-info</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label35">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">MP3 Encoder is not present.</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <object class="GtkLinkButton" id="linkbutton1">
-                            <property name="label" translatable="yes">Read how to install</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                            <property name="has-tooltip">True</property>
-                            <property name="relief">none</property>
-                            <property name="uri">http://soundconverter.org/gstreamer-mp3-encoding-howto/</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkImage" id="image23">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">gtk-dialog-info</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label35">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">MP3 Encoder is not present.</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <object class="GtkLinkButton" id="linkbutton1">
+                                <property name="label" translatable="yes">Read how to install</property>
+                                <property name="use-action-appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="relief">none</property>
+                                <property name="uri">http://soundconverter.org/gstreamer-mp3-encoding-howto/</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">7</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">7</property>
-              </packing>
-            </child>
-          </object>
             </child>
           </object>
           <packing>


### PR DESCRIPTION
This allows the window to fit into smaller screens. Without this, the bottom of the dialog is off screen on a standard 1024x768 display.