### PR TITLE
Install icons into the hicolor directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,10 +63,14 @@ endif
 # Icons
 install_data(
   'data/soundconverter.png',
-  install_dir: join_paths(get_option('datadir'), 'pixmaps'),
+  install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '48x48', 'apps'),
 )
 install_data(
   'data/soundconverter.svg',
+  install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps'),
+)
+install_data(
+  'data/soundconverter-logo.svg',
   install_dir: join_paths(get_option('datadir'), 'soundconverter'),
 )
 


### PR DESCRIPTION
This is the standard place for the icons used by the desktop file and as the window icon.

Also install soundconverter-logo.svg into the data dir, which is used on the about dialog.